### PR TITLE
Add audio regeneration for retake (--regenerate-audio)

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,6 +305,7 @@ flowchart TD
 | `--enhance-prompt` | off | Enhance prompt with Gemma VLM |
 | `--transformer-quant` | `bf16` | Quantization: `bf16`, `qint8`, `int4` |
 | `--mixed-precision` | off | Per-block quantization: first/last 6 blocks qint8, middle int4 |
+| `--regenerate-audio` | off | Regenerate audio via dual denoising (default: preserve source audio) |
 | `--profile` | off | GPU/CPU profiling report + Chrome Trace export |
 
 ### `ltx-video train`

--- a/Sources/LTXVideo/Configuration/LTXConfig.swift
+++ b/Sources/LTXVideo/Configuration/LTXConfig.swift
@@ -337,6 +337,11 @@ public struct LTXVideoGenerationConfig: Sendable {
     /// End time (seconds) for partial retake. nil = retake all frames.
     public var retakeEndTime: Float?
 
+    /// Whether to regenerate audio during retake (requires audio models loaded).
+    /// When false (default), source audio is preserved via passthrough.
+    /// When true, audio is denoised alongside video using LTX2Transformer.
+    public var regenerateAudio: Bool
+
     public init(
         width: Int = 704,
         height: Int = 480,
@@ -349,7 +354,8 @@ public struct LTXVideoGenerationConfig: Sendable {
         videoPath: String? = nil,
         retakeStrength: Float = 0.8,
         retakeStartTime: Float? = nil,
-        retakeEndTime: Float? = nil
+        retakeEndTime: Float? = nil,
+        regenerateAudio: Bool = false
     ) {
         self.width = width
         self.height = height
@@ -363,6 +369,7 @@ public struct LTXVideoGenerationConfig: Sendable {
         self.retakeStrength = retakeStrength
         self.retakeStartTime = retakeStartTime
         self.retakeEndTime = retakeEndTime
+        self.regenerateAudio = regenerateAudio
     }
 
     /// Convenience initializer that applies model-specific defaults.
@@ -379,7 +386,8 @@ public struct LTXVideoGenerationConfig: Sendable {
         videoPath: String? = nil,
         retakeStrength: Float = 0.8,
         retakeStartTime: Float? = nil,
-        retakeEndTime: Float? = nil
+        retakeEndTime: Float? = nil,
+        regenerateAudio: Bool = false
     ) {
         self.width = width
         self.height = height
@@ -393,6 +401,7 @@ public struct LTXVideoGenerationConfig: Sendable {
         self.retakeStrength = retakeStrength
         self.retakeStartTime = retakeStartTime
         self.retakeEndTime = retakeEndTime
+        self.regenerateAudio = regenerateAudio
     }
 
     /// Validate the configuration

--- a/Sources/LTXVideo/Pipeline/LTXPipeline.swift
+++ b/Sources/LTXVideo/Pipeline/LTXPipeline.swift
@@ -1181,8 +1181,9 @@ public actor LTXPipeline {
         }
 
         // Encode audio latents for cross-modal attention if LTX2Transformer + AudioVAE encoder are loaded
+        let regenerateAudio = config.regenerateAudio
         if ltx2Transformer != nil, let audioVAE = audioVAE, audioVAE.encoder != nil, let waveform = sourceAudioWaveform {
-            LTXDebug.log("Encoding source audio for cross-modal attention...")
+            LTXDebug.log("Encoding source audio for \(regenerateAudio ? "regeneration" : "cross-modal attention")...")
             let melSpec = audioProcessor.melSpectrogram(waveform)
             eval(melSpec)
 
@@ -1366,6 +1367,15 @@ public actor LTXPipeline {
         }
         MLX.eval(videoLatent)
 
+        // Audio regeneration: noise the audio latents (same as video)
+        var audioLatentPacked: MLXArray? = nil
+        if regenerateAudio, let cleanAudio = frozenAudioLatentPacked {
+            let audioNoise = MLXRandom.normal(cleanAudio.shape).asType(cleanAudio.dtype)
+            audioLatentPacked = audioNoise  // Start from pure noise (full regeneration)
+            frozenAudioLatentPacked = nil   // Don't freeze — will be denoised
+            LTXDebug.log("Audio latents noised for regeneration: \(audioNoise.shape)")
+        }
+
         // Denoising loop (matching Lightricks euler_denoising_loop)
         let modeStr = isPartialRetake ? "partial" : "full"
         LTXDebug.log("=== Single-stage \(modeStr) retake denoising (\(numSteps) steps) ===")
@@ -1403,20 +1413,27 @@ public actor LTXPipeline {
             // Helper: run transformer and compute denoised x0
             func runTransformer(context: MLXArray, audioContext: MLXArray) -> MLXArray {
                 if let ltx2 = ltx2Transformer {
-                    let audioInput = frozenAudioLatentPacked ?? MLXArray.zeros([videoPatchified.dim(0), 1, 128]).asType(DType.bfloat16)
-                    let audioFrames = frozenAudioLatentPacked != nil ? retakeAudioNumFrames : 1
-                    let (velPred, _) = ltx2(
+                    let audioInput = audioLatentPacked ?? frozenAudioLatentPacked ?? MLXArray.zeros([videoPatchified.dim(0), 1, 128]).asType(DType.bfloat16)
+                    let audioFrames = (audioLatentPacked != nil || frozenAudioLatentPacked != nil) ? retakeAudioNumFrames : 1
+                    let audioTs = regenerateAudio ? MLXArray([sigma]) : MLXArray([Float(0)])
+                    let (velPred, audioVelPred) = ltx2(
                         videoLatent: videoPatchified,
                         audioLatent: audioInput,
                         videoContext: context.asType(.bfloat16),
                         audioContext: audioContext.asType(.bfloat16),
                         videoTimesteps: videoTimestep,
-                        audioTimesteps: MLXArray([Float(0)]),
+                        audioTimesteps: audioTs,
                         videoContextMask: nil,
                         audioContextMask: nil,
                         videoLatentShape: (frames: latentShape.frames, height: latentShape.height, width: latentShape.width),
                         audioNumFrames: audioFrames
                     )
+                    // Audio Euler step (when regenerating)
+                    if regenerateAudio, var ap = audioLatentPacked {
+                        let audioVel = audioVelPred.asType(.float32)
+                        ap = ap.asType(.float32) + MLXArray(sigmaNext - sigma) * audioVel
+                        audioLatentPacked = ap.asType(DType.bfloat16)
+                    }
                     let vel = unpatchify(velPred, shape: latentShape).asType(.float32)
                     return videoLatent - sigma5d * vel
                 } else if let videoTransformer = transformer {
@@ -1521,19 +1538,46 @@ public actor LTXPipeline {
             trimmedVideo = videoTensor
         }
 
+        // Decode regenerated audio if applicable
+        var audioWaveform: MLXArray? = nil
+        var audioSampleRate: Int? = nil
+        if regenerateAudio, let ap = audioLatentPacked,
+           let audioVAE = audioVAE, let vocoder = vocoder {
+            LTXDebug.log("Decoding regenerated audio...")
+            let audioLatentUnpacked = unpackAudioLatents(ap, numFrames: retakeAudioNumFrames)
+            audioWaveform = decodeAudio(
+                latents: audioLatentUnpacked,
+                audioVAE: audioVAE,
+                vocoder: vocoder
+            )
+            MLX.eval(audioWaveform!)
+            audioSampleRate = vocoder.outputSampleRate
+            LTXDebug.log("Regenerated audio: \(audioWaveform!.shape)")
+        }
+
         LTXMemoryManager.resetCacheLimit()
 
         let generationTime = Date().timeIntervalSince(generationStart)
         LTXDebug.log("Total retake generation time: \(String(format: "%.1f", generationTime))s")
 
-        return VideoGenerationResult(
-            frames: trimmedVideo,
-            seed: config.seed ?? 0,
-            generationTime: generationTime,
-            
-            effectivePrompt: effectivePrompt,
-            sourceAudioPath: videoPath
-        )
+        if regenerateAudio {
+            return VideoGenerationResult(
+                frames: trimmedVideo,
+                seed: config.seed ?? 0,
+                generationTime: generationTime,
+                audioWaveform: audioWaveform,
+                audioSampleRate: audioSampleRate,
+                effectivePrompt: effectivePrompt
+            )
+        } else {
+            return VideoGenerationResult(
+                frames: trimmedVideo,
+                seed: config.seed ?? 0,
+                generationTime: generationTime,
+                effectivePrompt: effectivePrompt,
+                sourceAudioPath: videoPath
+            )
+        }
     }
 
     /// Encode a video into latent space using the VAE encoder

--- a/Sources/LTXVideo/Pipeline/LTXPipeline.swift
+++ b/Sources/LTXVideo/Pipeline/LTXPipeline.swift
@@ -1371,7 +1371,8 @@ public actor LTXPipeline {
         // Audio regeneration: noise the audio latents (same as video)
         var audioLatentPacked: MLXArray? = nil
         if regenerateAudio, let cleanAudio = frozenAudioLatentPacked {
-            let audioNoise = MLXRandom.normal(cleanAudio.shape).asType(cleanAudio.dtype)
+            // Noise in float32 (matching generateVideo pattern — "Float32 latents" rule)
+            let audioNoise = MLXRandom.normal(cleanAudio.shape).asType(.float32)
             audioLatentPacked = audioNoise  // Start from pure noise (full regeneration)
             frozenAudioLatentPacked = nil   // Don't freeze — will be denoised
             LTXDebug.log("Audio latents noised for regeneration: \(audioNoise.shape)")
@@ -1414,7 +1415,7 @@ public actor LTXPipeline {
             // Helper: run transformer and compute denoised x0
             func runTransformer(context: MLXArray, audioContext: MLXArray) -> MLXArray {
                 if let ltx2 = ltx2Transformer {
-                    let audioInput = audioLatentPacked ?? frozenAudioLatentPacked ?? MLXArray.zeros([videoPatchified.dim(0), 1, 128]).asType(DType.bfloat16)
+                    let audioInput = (audioLatentPacked ?? frozenAudioLatentPacked ?? MLXArray.zeros([videoPatchified.dim(0), 1, 128])).asType(DType.bfloat16)
                     let audioFrames = (audioLatentPacked != nil || frozenAudioLatentPacked != nil) ? retakeAudioNumFrames : 1
                     let audioTs = regenerateAudio ? MLXArray([sigma]) : MLXArray([Float(0)])
                     let (velPred, audioVelPred) = ltx2(
@@ -1430,10 +1431,10 @@ public actor LTXPipeline {
                         audioNumFrames: audioFrames
                     )
                     // Audio Euler step (when regenerating)
-                    if regenerateAudio, var ap = audioLatentPacked {
+                    // Keep audio latents in float32 between steps (cast to bf16 only for transformer input)
+                    if regenerateAudio, let ap = audioLatentPacked {
                         let audioVel = audioVelPred.asType(.float32)
-                        ap = ap.asType(.float32) + MLXArray(sigmaNext - sigma) * audioVel
-                        audioLatentPacked = ap.asType(DType.bfloat16)
+                        audioLatentPacked = ap.asType(.float32) + MLXArray(sigmaNext - sigma) * audioVel
                     }
                     let vel = unpatchify(velPred, shape: latentShape).asType(.float32)
                     return videoLatent - sigma5d * vel

--- a/Sources/LTXVideo/Pipeline/LTXPipeline.swift
+++ b/Sources/LTXVideo/Pipeline/LTXPipeline.swift
@@ -447,6 +447,7 @@ public actor LTXPipeline {
     /// - Important: Call `loadModels()` first, then `loadAudioModels()`. The audio
     ///   transformer weights are in the same unified file and share video weights.
     public func loadAudioModels(
+        includeEncoder: Bool = false,
         progressCallback: DownloadProgressCallback? = nil
     ) async throws {
         LTXDebug.log("Loading audio models...")
@@ -456,9 +457,9 @@ public actor LTXPipeline {
         let audioVAEPath = try await downloader.downloadAudioVAE { progress in
             progressCallback?(progress)
         }
-        let audioVAEWeights = try LTXWeightLoader.loadAudioVAEWeights(from: audioVAEPath.path)
+        let audioVAEWeights = try LTXWeightLoader.loadAudioVAEWeights(from: audioVAEPath.path, includeEncoder: includeEncoder)
 
-        audioVAE = AudioVAE()
+        audioVAE = AudioVAE(includeEncoder: includeEncoder)
         try LTXWeightLoader.applyAudioVAEWeights(audioVAEWeights, to: audioVAE!)
         LTXDebug.log("Audio VAE loaded")
 

--- a/Sources/LTXVideoCLI/LTXVideoCLI.swift
+++ b/Sources/LTXVideoCLI/LTXVideoCLI.swift
@@ -357,6 +357,9 @@ struct Retake: AsyncParsableCommand {
     @Flag(name: .long, help: "Use distilled model (8 steps, fast) instead of dev (30 steps + CFG)")
     var distilled: Bool = false
 
+    @Flag(name: .long, help: "Regenerate audio (instead of preserving source audio)")
+    var regenerateAudio: Bool = false
+
     @Option(name: .long, help: "Transformer quantization: bf16 (default), qint8, or int4")
     var transformerQuant: String = "bf16"
 
@@ -482,6 +485,16 @@ struct Retake: AsyncParsableCommand {
         let loadTime = Date().timeIntervalSince(startLoad)
         print("Models loaded in \(String(format: "%.1f", loadTime))s")
 
+        // Load audio models if regenerating audio
+        if regenerateAudio {
+            print("Loading audio models...")
+            fflush(stdout)
+            try await pipeline.loadAudioModels { progress in
+                print("  \(progress.message) (\(Int(progress.progress * 100))%)")
+            }
+            print("Audio models loaded")
+        }
+
         // Build config
         let config = LTXVideoGenerationConfig(
             width: width,
@@ -493,7 +506,8 @@ struct Retake: AsyncParsableCommand {
             videoPath: video,
             retakeStrength: strength,
             retakeStartTime: startTime,
-            retakeEndTime: endTime
+            retakeEndTime: endTime,
+            regenerateAudio: regenerateAudio
         )
 
         // Generate retake (single-stage, no upscaler needed)
@@ -525,19 +539,44 @@ struct Retake: AsyncParsableCommand {
             print("Using target bitrate: \(kbps) kbps")
         }
 
-        // Use source audio passthrough (copy audio track directly, no re-encode)
-        let sourceAudioURL = URL(fileURLWithPath: video)
-        let videoURL = try await VideoExporter.exportVideo(
-            frames: result.frames,
-            width: width,
-            height: height,
-            fps: 24.0,
-            sourceAudioURL: sourceAudioURL,
-            config: exportConfig,
-            to: outputURL
-        )
-        print("Video saved to: \(videoURL.path)")
-        print("Audio: source audio preserved")
+        if let audioWaveform = result.audioWaveform, let audioSampleRate = result.audioSampleRate {
+            // Regenerated audio: mux video + new audio
+            let videoURL = try await VideoExporter.exportVideo(
+                frames: result.frames,
+                width: width,
+                height: height,
+                fps: 24.0,
+                audioWaveform: audioWaveform,
+                audioSampleRate: audioSampleRate,
+                config: exportConfig,
+                to: outputURL
+            )
+            print("Video saved to: \(videoURL.path)")
+            print("Audio: regenerated")
+
+            // Also export standalone WAV
+            let wavPath = output.replacingOccurrences(of: ".mp4", with: ".wav")
+            try AudioExporter.exportToWAV(
+                waveform: audioWaveform,
+                sampleRate: audioSampleRate,
+                path: wavPath
+            )
+            print("Audio WAV saved to: \(wavPath)")
+        } else {
+            // Source audio passthrough (copy audio track directly, no re-encode)
+            let sourceAudioURL = URL(fileURLWithPath: video)
+            let videoURL = try await VideoExporter.exportVideo(
+                frames: result.frames,
+                width: width,
+                height: height,
+                fps: 24.0,
+                sourceAudioURL: sourceAudioURL,
+                config: exportConfig,
+                to: outputURL
+            )
+            print("Video saved to: \(videoURL.path)")
+            print("Audio: source audio preserved")
+        }
 
         // Print summary
         print("\n--- Summary ---")

--- a/Sources/LTXVideoCLI/LTXVideoCLI.swift
+++ b/Sources/LTXVideoCLI/LTXVideoCLI.swift
@@ -487,9 +487,9 @@ struct Retake: AsyncParsableCommand {
 
         // Load audio models if regenerating audio
         if regenerateAudio {
-            print("Loading audio models...")
+            print("Loading audio models (with encoder)...")
             fflush(stdout)
-            try await pipeline.loadAudioModels { progress in
+            try await pipeline.loadAudioModels(includeEncoder: true) { progress in
                 print("  \(progress.message) (\(Int(progress.progress * 100))%)")
             }
             print("Audio models loaded")

--- a/Tests/LTXVideoTests/LTXConfigTests.swift
+++ b/Tests/LTXVideoTests/LTXConfigTests.swift
@@ -261,6 +261,21 @@ struct LTXVideoGenerationConfigTests {
         #expect(config.retakeStrength == 0.7)
         #expect(config.retakeStartTime == 2.0)
         #expect(config.retakeEndTime == 5.0)
+        #expect(config.regenerateAudio == false)
+    }
+
+    @Test func testRegenerateAudioDefault() {
+        let config = LTXVideoGenerationConfig()
+        #expect(config.regenerateAudio == false)
+    }
+
+    @Test func testRegenerateAudioEnabled() {
+        let config = LTXVideoGenerationConfig(
+            videoPath: "/tmp/vid.mp4",
+            regenerateAudio: true
+        )
+        #expect(config.regenerateAudio == true)
+        #expect(config.videoPath == "/tmp/vid.mp4")
     }
 
     // MARK: - Retake Temporal Mask Tests


### PR DESCRIPTION
## Summary

Closes #11. Adds `--regenerate-audio` flag to retake command, matching the Lightricks reference which supports independent video and audio regeneration.

### How it works

| Mode | Audio | Video |
|---|---|---|
| Default (no flag) | Source audio preserved (passthrough) | Regenerated by prompt |
| `--regenerate-audio` | Regenerated by LTX2Transformer | Regenerated by prompt |

When enabled:
1. Source audio → mel spectrogram → AudioVAE encoder → audio latents
2. Audio latents noised (pure noise, like video)
3. LTX2Transformer denoises video + audio simultaneously (audioTimesteps=sigma)
4. Audio Euler step: `audio += (sigmaNext - sigma) * audioVelocity`
5. Audio decoded: AudioVAE decoder → vocoder → 24kHz waveform
6. Exported as MP4 (muxed) + WAV (standalone)

### Usage

```bash
# Retake with new audio
ltx-video retake "An explosion with fire and debris" \
    --video source.mp4 --regenerate-audio \
    -w 768 -h 512 -f 121

# Default: keep source audio (unchanged behavior)
ltx-video retake "A cat playing" --video source.mp4
```

### Files changed

| File | Change |
|---|---|
| `LTXConfig.swift` | `regenerateAudio` field |
| `LTXPipeline.swift` | Audio noising, Euler step, decoding in retake |
| `LTXVideoCLI.swift` | `--regenerate-audio` flag, audio model loading, export logic |

## Test plan

- [x] 143 unit tests pass
- [x] `swift build` compiles
- [x] `--regenerate-audio` flag visible in `retake --help`
- [ ] Integration test: retake with `--regenerate-audio` on a video with audio

🤖 Generated with [Claude Code](https://claude.com/claude-code)