### PR TITLE
Fix #21: keyframe append (clean middle/last frames)

### DIFF
--- a/Sources/LTXVideo/Configuration/LTXConfig.swift
+++ b/Sources/LTXVideo/Configuration/LTXConfig.swift
@@ -317,10 +317,17 @@ public struct LTXVideoGenerationConfig: Sendable {
     /// nil = text-to-video (default), non-nil = image-to-video.
     public var imagePath: String?
 
-    /// Noise scale for image conditioning. Adds quadratically-decreasing noise to the
-    /// conditioned frame to allow smoother motion transitions. 0.0 = disabled (matches Diffusers default),
-    /// 0.15 = optional for natural motion.
-    public var imageCondNoiseScale: Float
+    /// **Deprecated, no-op.** Used by the legacy hard-injection keyframe path which
+    /// re-injected the keyframe slot pre-step with σ-scaled noise. The current append-based
+    /// keyframe path keeps guide tokens at σ=0 throughout, so this value is ignored.
+    /// Field kept to preserve source-compat for SPM consumers.
+    @available(*, deprecated, message: "No-op since the keyframe-append fix (issue #21). Will be removed in a future major release.")
+    public var imageCondNoiseScale: Float {
+        get { _imageCondNoiseScale }
+        set { _imageCondNoiseScale = newValue }
+    }
+    // Backing storage so internal init assignments don't trip the deprecation warning.
+    private var _imageCondNoiseScale: Float
 
     /// Source video path for retake (video-to-video) mode. nil = generate from scratch.
     public var videoPath: String?
@@ -371,7 +378,7 @@ public struct LTXVideoGenerationConfig: Sendable {
         self.seed = seed
         self.enhancePrompt = enhancePrompt
         self.imagePath = imagePath
-        self.imageCondNoiseScale = imageCondNoiseScale
+        self._imageCondNoiseScale = imageCondNoiseScale
         self.videoPath = videoPath
         self.retakeStrength = retakeStrength
         self.retakeStartTime = retakeStartTime
@@ -405,7 +412,7 @@ public struct LTXVideoGenerationConfig: Sendable {
         self.seed = seed
         self.enhancePrompt = enhancePrompt
         self.imagePath = imagePath
-        self.imageCondNoiseScale = imageCondNoiseScale
+        self._imageCondNoiseScale = imageCondNoiseScale
         self.videoPath = videoPath
         self.retakeStrength = retakeStrength
         self.retakeStartTime = retakeStartTime

--- a/Sources/LTXVideo/Models/Transformer/LTX2Transformer.swift
+++ b/Sources/LTXVideo/Models/Transformer/LTX2Transformer.swift
@@ -285,7 +285,9 @@ class LTX2Transformer: Module {
         videoContextMask: MLXArray? = nil,
         audioContextMask: MLXArray? = nil,
         videoLatentShape: (frames: Int, height: Int, width: Int),
-        audioNumFrames: Int
+        audioNumFrames: Int,
+        precomputedVideoRoPE: (cos: MLXArray, sin: MLXArray)? = nil,
+        precomputedCrossVideoRoPE: (cos: MLXArray, sin: MLXArray)? = nil
     ) -> (video: MLXArray, audio: MLXArray) {
         let batchSize = videoLatent.dim(0)
         let videoDim = config.innerDim
@@ -380,21 +382,49 @@ class LTX2Transformer: Module {
         let preparedAudioMask = prepareAttentionMask(audioContextMask)
 
         // --- Prepare RoPE ---
-        let videoRoPE = prepareVideoRoPE(
-            batchSize: batchSize,
-            frames: videoLatentShape.frames,
-            height: videoLatentShape.height,
-            width: videoLatentShape.width
-        )
+        // When precomputed video RoPE is provided (appended-guide-tokens path),
+        // use it directly — the caller computed positions for an extended sequence
+        // that includes guide tokens beyond the (frames, height, width) shape.
+        let videoRoPE: (cos: MLXArray, sin: MLXArray)
+        if let custom = precomputedVideoRoPE {
+            videoRoPE = custom
+        } else {
+            videoRoPE = prepareVideoRoPE(
+                batchSize: batchSize,
+                frames: videoLatentShape.frames,
+                height: videoLatentShape.height,
+                width: videoLatentShape.width
+            )
+        }
         let audioRoPE = prepareAudioRoPE(batchSize: batchSize, audioFrames: audioNumFrames)
 
-        let (crossVideoRoPE, crossAudioRoPE) = prepareCrossModalRoPE(
-            batchSize: batchSize,
-            videoFrames: videoLatentShape.frames,
-            videoHeight: videoLatentShape.height,
-            videoWidth: videoLatentShape.width,
-            audioFrames: audioNumFrames
-        )
+        // Cross-modal RoPE: video side uses temporal-only positions, audio side likewise.
+        // For appended-guide tokens, the cross-modal video RoPE must also be extended
+        // so that the appended video tokens have a temporal coordinate when attending to audio.
+        let crossVideoRoPE: (cos: MLXArray, sin: MLXArray)
+        let crossAudioRoPE: (cos: MLXArray, sin: MLXArray)
+        if let customCV = precomputedCrossVideoRoPE {
+            crossVideoRoPE = customCV
+            // Compute audio cross-modal RoPE the normal way
+            let audioPositions = createAudioPositionGrid(batchSize: batchSize, audioFrames: audioNumFrames)
+            crossAudioRoPE = precomputeFreqsCis(
+                indicesGrid: audioPositions,
+                dim: config.audioCrossAttentionDim,
+                theta: config.ropeTheta,
+                maxPos: config.audioMaxPos,
+                numAttentionHeads: config.audioNumAttentionHeads,
+                ropeType: ropeType,
+                doublePrecision: true
+            )
+        } else {
+            (crossVideoRoPE, crossAudioRoPE) = prepareCrossModalRoPE(
+                batchSize: batchSize,
+                videoFrames: videoLatentShape.frames,
+                videoHeight: videoLatentShape.height,
+                videoWidth: videoLatentShape.width,
+                audioFrames: audioNumFrames
+            )
+        }
 
         eval(videoX, audioX, videoTembReshaped, audioTembReshaped)
 

--- a/Sources/LTXVideo/Models/Transformer/LTXTransformer.swift
+++ b/Sources/LTXVideo/Models/Transformer/LTXTransformer.swift
@@ -344,10 +344,10 @@ class LTXTransformer: Module {
         let preparedMask = prepareAttentionMask(contextMask)
 
         // Prepare positional embeddings (RoPE)
-        // When precomputedRoPE is provided (prototype: appended guide tokens with
-        // custom positions), use it directly and skip the cached derivation from
-        // latentShape. The caller is responsible for matching pe.cos/sin token count
-        // with latent.dim(1).
+        // When precomputedRoPE is provided (e.g. appended keyframe guide tokens
+        // with custom RoPE positions), use it directly and skip the cached
+        // derivation from latentShape. The caller is responsible for matching the
+        // pe.cos/sin token count with latent.dim(1).
         let pe: (cos: MLXArray, sin: MLXArray)
         if let custom = precomputedRoPE {
             pe = custom

--- a/Sources/LTXVideo/Models/Transformer/LTXTransformer.swift
+++ b/Sources/LTXVideo/Models/Transformer/LTXTransformer.swift
@@ -261,7 +261,8 @@ class LTXTransformer: Module {
         context: MLXArray,
         timesteps: MLXArray,
         contextMask: MLXArray? = nil,
-        latentShape: (frames: Int, height: Int, width: Int)
+        latentShape: (frames: Int, height: Int, width: Int),
+        precomputedRoPE: (cos: MLXArray, sin: MLXArray)? = nil
     ) -> MLXArray {
         let startTime = Date()
         var lastTime = startTime
@@ -343,12 +344,21 @@ class LTXTransformer: Module {
         let preparedMask = prepareAttentionMask(contextMask)
 
         // Prepare positional embeddings (RoPE)
-        let pe = preparePositionalEmbeddings(
-            batchSize: batchSize,
-            frames: latentShape.frames,
-            height: latentShape.height,
-            width: latentShape.width
-        )
+        // When precomputedRoPE is provided (prototype: appended guide tokens with
+        // custom positions), use it directly and skip the cached derivation from
+        // latentShape. The caller is responsible for matching pe.cos/sin token count
+        // with latent.dim(1).
+        let pe: (cos: MLXArray, sin: MLXArray)
+        if let custom = precomputedRoPE {
+            pe = custom
+        } else {
+            pe = preparePositionalEmbeddings(
+                batchSize: batchSize,
+                frames: latentShape.frames,
+                height: latentShape.height,
+                width: latentShape.width
+            )
+        }
         eval(pe.cos, pe.sin)
         now = Date()
         LTXDebug.log("  [TIME] preparePositionalEmbeddings (RoPE): \(String(format: "%.3f", now.timeIntervalSince(lastTime)))s")

--- a/Sources/LTXVideo/Pipeline/AppendedGuideTokens.swift
+++ b/Sources/LTXVideo/Pipeline/AppendedGuideTokens.swift
@@ -1,0 +1,131 @@
+// AppendedGuideTokens.swift — Prototype primitive for keyframe append fix (issue #21)
+// Copyright 2025
+
+import Foundation
+@preconcurrency import MLX
+
+struct AppendedGuideTokens {
+    let tokens: MLXArray
+    let positions: MLXArray
+}
+
+func appendVideoGuides(
+    videoTokens: MLXArray,
+    basePositions: MLXArray,
+    guides: [AppendedGuideTokens]
+) -> (tokens: MLXArray, positions: MLXArray, originalCount: Int) {
+    let originalCount = videoTokens.dim(1)
+    guard !guides.isEmpty else {
+        return (videoTokens, basePositions, originalCount)
+    }
+
+    var allTokens: [MLXArray] = [videoTokens]
+    var allPositions: [MLXArray] = [basePositions]
+    for g in guides {
+        allTokens.append(g.tokens)
+        allPositions.append(g.positions)
+    }
+    let tokens = MLX.concatenated(allTokens, axis: 1)
+    let positions = MLX.concatenated(allPositions, axis: 2)
+    return (tokens, positions, originalCount)
+}
+
+func buildExtendedTimestep(
+    sigma: Float,
+    originalCount: Int,
+    guideCount: Int,
+    batchSize: Int = 1
+) -> MLXArray {
+    let totalCount = originalCount + guideCount
+    var values = [Float](repeating: sigma, count: totalCount)
+    for i in originalCount..<totalCount {
+        values[i] = 0.0
+    }
+    let arr = MLXArray(values, [1, totalCount])
+    if batchSize == 1 {
+        return arr
+    }
+    return MLX.broadcast(arr, to: [batchSize, totalCount])
+}
+
+func cropToOriginal(velocity: MLXArray, originalCount: Int) -> MLXArray {
+    return velocity[0..., 0..<originalCount, 0...]
+}
+
+/// Build a guide token group from a VAE-encoded keyframe latent.
+///
+/// Replicates Lightricks `VideoConditionByKeyframeIndex` semantics for `num_pixel_frames=1`:
+/// the temporal position is `(pixelFrameIndex + 0.5) / fps` (the "middle" of a 1-frame range
+/// starting at `pixelFrameIndex`), spatial positions are pixel-space middles like the base
+/// sequence. This matches the Swift RoPE convention (middle of bounds, not start/end pair).
+///
+/// - Parameters:
+///   - encodedLatent: VAE-encoded keyframe of shape `(1, 128, 1, latentH, latentW)`,
+///                    already normalized via per-channel stats.
+///   - pixelFrameIndex: Target pixel frame index where this keyframe should sit (0-based).
+///   - fps: Pixel frame rate, default 24.0 (matches createPositionGrid default).
+///   - spatialScale: VAE spatial compression factor, default 32.
+///   - dtype: Output dtype for the token tensor; positions stay float32.
+func buildKeyframeGuideToken(
+    encodedLatent: MLXArray,
+    pixelFrameIndex: Int,
+    fps: Float = 24.0,
+    spatialScale: Int = 32,
+    dtype: DType = .bfloat16
+) -> AppendedGuideTokens {
+    let h = encodedLatent.dim(3)
+    let w = encodedLatent.dim(4)
+    let numTokens = h * w
+
+    let patched = patchify(encodedLatent).asType(dtype)
+
+    let tPos = (Float(pixelFrameIndex) + 0.5) / fps
+    let tCoords = [Float](repeating: tPos, count: numTokens)
+
+    let sScale = Float(spatialScale)
+    var hCoords = [Float]()
+    hCoords.reserveCapacity(numTokens)
+    var wCoords = [Float]()
+    wCoords.reserveCapacity(numTokens)
+    for hi in 0..<h {
+        let hp = Float(hi) * sScale + sScale / 2.0
+        for wi in 0..<w {
+            let wp = Float(wi) * sScale + sScale / 2.0
+            hCoords.append(hp)
+            wCoords.append(wp)
+        }
+    }
+
+    let tArr = MLXArray(tCoords)
+    let hArr = MLXArray(hCoords)
+    let wArr = MLXArray(wCoords)
+    let stacked = MLX.stacked([tArr, hArr, wArr], axis: 0)
+    let positions = stacked.expandedDimensions(axis: 0).asType(.float32)
+
+    return AppendedGuideTokens(tokens: patched, positions: positions)
+}
+
+/// Construct the base position grid for a video latent (same as createPositionGrid)
+/// but exposed here so the pipeline can extend it with guide positions before
+/// calling precomputeFreqsCis.
+func buildBaseVideoPositions(
+    batchSize: Int,
+    frames: Int,
+    height: Int,
+    width: Int,
+    temporalScale: Int = 8,
+    spatialScale: Int = 32,
+    fps: Float = 24.0,
+    causalFix: Bool = true
+) -> MLXArray {
+    return createPositionGrid(
+        batchSize: batchSize,
+        frames: frames,
+        height: height,
+        width: width,
+        temporalScale: temporalScale,
+        spatialScale: spatialScale,
+        fps: fps,
+        causalFix: causalFix
+    )
+}

--- a/Sources/LTXVideo/Pipeline/AppendedGuideTokens.swift
+++ b/Sources/LTXVideo/Pipeline/AppendedGuideTokens.swift
@@ -1,35 +1,26 @@
-// AppendedGuideTokens.swift — Prototype primitive for keyframe append fix (issue #21)
+// AppendedGuideTokens.swift — Keyframe conditioning via appended guide tokens (issue #21 fix)
 // Copyright 2025
 
 import Foundation
 @preconcurrency import MLX
 
+/// A group of "guide tokens" that get concatenated to the video token sequence
+/// inside the transformer to condition generation on a keyframe image.
+///
+/// - `tokens`: patchified VAE-encoded keyframe, shape `(1, K, C)` where
+///   `K = latentH * latentW` and `C` is the VAE channel count (128 for LTX-2.3).
+/// - `positions`: 3D RoPE positions for those tokens, shape `(1, 3, K)`. The
+///   temporal coord points to `(pixelFrameIndex + 0.5) / fps` (single-frame
+///   narrowing per Lightricks `keyframe_cond.py`); spatial coords are the same
+///   pixel-space midpoints used by the base video sequence.
 struct AppendedGuideTokens {
     let tokens: MLXArray
     let positions: MLXArray
 }
 
-func appendVideoGuides(
-    videoTokens: MLXArray,
-    basePositions: MLXArray,
-    guides: [AppendedGuideTokens]
-) -> (tokens: MLXArray, positions: MLXArray, originalCount: Int) {
-    let originalCount = videoTokens.dim(1)
-    guard !guides.isEmpty else {
-        return (videoTokens, basePositions, originalCount)
-    }
-
-    var allTokens: [MLXArray] = [videoTokens]
-    var allPositions: [MLXArray] = [basePositions]
-    for g in guides {
-        allTokens.append(g.tokens)
-        allPositions.append(g.positions)
-    }
-    let tokens = MLX.concatenated(allTokens, axis: 1)
-    let positions = MLX.concatenated(allPositions, axis: 2)
-    return (tokens, positions, originalCount)
-}
-
+/// Build a per-token timestep tensor of shape `(B, originalCount + guideCount)` where
+/// the first `originalCount` tokens hold the schedule's current `sigma` and the
+/// trailing `guideCount` tokens hold `0` (clean reference, no denoising).
 func buildExtendedTimestep(
     sigma: Float,
     originalCount: Int,
@@ -48,6 +39,9 @@ func buildExtendedTimestep(
     return MLX.broadcast(arr, to: [batchSize, totalCount])
 }
 
+/// Slice `velocity` (shape `(B, T_total, C)`) down to the first `originalCount`
+/// tokens — the appended guide tokens' predicted velocity is discarded since the
+/// guides never enter the denoised latent.
 func cropToOriginal(velocity: MLXArray, originalCount: Int) -> MLXArray {
     return velocity[0..., 0..<originalCount, 0...]
 }
@@ -65,7 +59,9 @@ func cropToOriginal(velocity: MLXArray, originalCount: Int) -> MLXArray {
 ///   - pixelFrameIndex: Target pixel frame index where this keyframe should sit (0-based).
 ///   - fps: Pixel frame rate, default 24.0 (matches createPositionGrid default).
 ///   - spatialScale: VAE spatial compression factor, default 32.
-///   - dtype: Output dtype for the token tensor; positions stay float32.
+///   - dtype: Output dtype for the token tensor — must match the dtype the
+///            transformer expects for its patchified video latent input
+///            (bfloat16 today). Positions stay float32 for RoPE precision.
 func buildKeyframeGuideToken(
     encodedLatent: MLXArray,
     pixelFrameIndex: Int,
@@ -103,29 +99,4 @@ func buildKeyframeGuideToken(
     let positions = stacked.expandedDimensions(axis: 0).asType(.float32)
 
     return AppendedGuideTokens(tokens: patched, positions: positions)
-}
-
-/// Construct the base position grid for a video latent (same as createPositionGrid)
-/// but exposed here so the pipeline can extend it with guide positions before
-/// calling precomputeFreqsCis.
-func buildBaseVideoPositions(
-    batchSize: Int,
-    frames: Int,
-    height: Int,
-    width: Int,
-    temporalScale: Int = 8,
-    spatialScale: Int = 32,
-    fps: Float = 24.0,
-    causalFix: Bool = true
-) -> MLXArray {
-    return createPositionGrid(
-        batchSize: batchSize,
-        frames: frames,
-        height: height,
-        width: width,
-        temporalScale: temporalScale,
-        spatialScale: spatialScale,
-        fps: fps,
-        causalFix: causalFix
-    )
 }

--- a/Sources/LTXVideo/Pipeline/AppendedGuideTokens.swift
+++ b/Sources/LTXVideo/Pipeline/AppendedGuideTokens.swift
@@ -18,6 +18,107 @@ struct AppendedGuideTokens {
     let positions: MLXArray
 }
 
+/// All the constant-across-denoising-steps state needed to run a stage with
+/// appended keyframe guide tokens. Built once per stage by `prepareKeyframeAppend`,
+/// consumed each step by the transformer call site.
+///
+/// - `guideTokens`: concatenated keyframe tokens, shape `(1, K_total, C)`.
+/// - `extRoPE`: RoPE for the full extended sequence (video + guides), one
+///   `(cos, sin)` pair shared by `LTXTransformer.precomputedRoPE` and
+///   `LTX2Transformer.precomputedVideoRoPE`.
+/// - `extCrossVideoRoPE`: cross-modal video RoPE (temporal-only) for the
+///   extended sequence — only set when audio is enabled, used by
+///   `LTX2Transformer.precomputedCrossVideoRoPE`.
+/// - `originalCount`: token count of the un-extended video latent — what the
+///   scheduler step operates on after `cropToOriginal`.
+/// - `guideCount`: total appended guide token count (sum over all keyframes).
+struct AppendKeyframeContext {
+    let guideTokens: MLXArray
+    let extRoPE: (cos: MLXArray, sin: MLXArray)
+    let extCrossVideoRoPE: (cos: MLXArray, sin: MLXArray)?
+    let originalCount: Int
+    let guideCount: Int
+}
+
+/// Build the constant-across-steps `AppendKeyframeContext` for one stage.
+///
+/// Encodes each keyframe into a guide token group, concatenates them, computes
+/// the extended RoPE (and the cross-modal video RoPE when audio is enabled).
+/// Returns `nil` when there are no keyframes.
+///
+/// - Parameters:
+///   - encoded: VAE-encoded keyframes (output of `encodeKeyframes`).
+///   - shape: latent shape of the stage (used for `originalCount` and base positions).
+///   - hasAudio: when `true`, also computes `extCrossVideoRoPE` for the LTX2 audio path.
+///   - refConfig: transformer config providing RoPE dimensions / theta / maxPos.
+///   - stageLabel: human-readable tag (e.g. "Stage 1") used in debug logs.
+func prepareKeyframeAppend(
+    encoded: [EncodedKeyframe],
+    shape: VideoLatentShape,
+    hasAudio: Bool,
+    refConfig: LTXTransformerConfig,
+    stageLabel: String
+) -> AppendKeyframeContext? {
+    guard !encoded.isEmpty else { return nil }
+
+    let basePos = createPositionGrid(
+        batchSize: 1,
+        frames: shape.frames,
+        height: shape.height,
+        width: shape.width
+    )
+    let guides = encoded.map { kf in
+        buildKeyframeGuideToken(
+            encodedLatent: kf.latent,
+            pixelFrameIndex: kf.pixelFrameIndex,
+            fps: 24.0
+        )
+    }
+    let allGuideTokens = MLX.concatenated(guides.map { $0.tokens }, axis: 1)
+    let allGuidePositions = MLX.concatenated(guides.map { $0.positions }, axis: 2)
+    let originalCount = shape.tokenCount
+    let guideCount = allGuideTokens.dim(1)
+
+    let extPositions = MLX.concatenated([basePos, allGuidePositions], axis: 2)
+
+    let pe = precomputeFreqsCis(
+        indicesGrid: extPositions,
+        dim: refConfig.innerDim,
+        theta: refConfig.ropeTheta,
+        maxPos: refConfig.maxPos,
+        numAttentionHeads: refConfig.numAttentionHeads,
+        ropeType: .split,
+        doublePrecision: true
+    )
+    MLX.eval(pe.cos, pe.sin)
+
+    var crossPE: (cos: MLXArray, sin: MLXArray)? = nil
+    if hasAudio {
+        let temporalOnly = extPositions[0..., 0..<1, 0...]
+        let crossRoPE = precomputeFreqsCis(
+            indicesGrid: temporalOnly,
+            dim: refConfig.audioCrossAttentionDim,
+            theta: refConfig.ropeTheta,
+            maxPos: refConfig.audioMaxPos,
+            numAttentionHeads: refConfig.audioNumAttentionHeads,
+            ropeType: .split,
+            doublePrecision: true
+        )
+        MLX.eval(crossRoPE.cos, crossRoPE.sin)
+        crossPE = crossRoPE
+    }
+
+    LTXDebug.log("[append] \(stageLabel) extended sequence: \(originalCount) video + \(guideCount) guide tokens")
+
+    return AppendKeyframeContext(
+        guideTokens: allGuideTokens,
+        extRoPE: pe,
+        extCrossVideoRoPE: crossPE,
+        originalCount: originalCount,
+        guideCount: guideCount
+    )
+}
+
 /// Build a per-token timestep tensor of shape `(B, originalCount + guideCount)` where
 /// the first `originalCount` tokens hold the schedule's current `sigma` and the
 /// trailing `guideCount` tokens hold `0` (clean reference, no denoising).

--- a/Sources/LTXVideo/Pipeline/KeyframeInterpolation.swift
+++ b/Sources/LTXVideo/Pipeline/KeyframeInterpolation.swift
@@ -12,6 +12,7 @@ import MLXRandom
 struct EncodedKeyframe {
     let latentIdx: Int
     let latent: MLXArray
+    let pixelFrameIndex: Int
 }
 
 // MARK: - Public Types

--- a/Sources/LTXVideo/Pipeline/KeyframeInterpolation.swift
+++ b/Sources/LTXVideo/Pipeline/KeyframeInterpolation.swift
@@ -3,12 +3,12 @@
 
 import Foundation
 @preconcurrency import MLX
-import MLXRandom
 
 // MARK: - Internal Types
 
-/// One keyframe after VAE encoding: its latent slot index plus the encoded tensor
-/// (shape `(1, 128, 1, latentH, latentW)`).
+/// One keyframe after VAE encoding: its latent slot index, the encoded tensor
+/// (shape `(1, 128, 1, latentH, latentW)`), and the original pixel-space index
+/// (used to compute the appended guide token's RoPE temporal position).
 struct EncodedKeyframe {
     let latentIdx: Int
     let latent: MLXArray
@@ -21,8 +21,6 @@ struct EncodedKeyframe {
 ///
 /// Multiple keyframes can be combined to interpolate between them — e.g. a first frame
 /// at position 0, an optional middle frame, and a last frame at `numFrames - 1`.
-///
-/// Pixel positions are mapped to latent positions internally (latent stride = 8).
 public struct KeyframeInput: Sendable, Equatable {
     /// Path to the keyframe image file.
     public let path: String
@@ -30,9 +28,9 @@ public struct KeyframeInput: Sendable, Equatable {
     /// Pixel-space frame index where this keyframe applies (0-based, < numFrames).
     public let pixelFrameIndex: Int
 
-    /// Conditioning strength. Currently must be `1.0` (hard injection — the latent
-    /// is forced to the encoded image). Values `!= 1.0` are rejected by
-    /// `validateKeyframes()` until soft conditioning is wired through.
+    /// Conditioning strength in `(0, 1]`. `1.0` = clean reference (σ=0 on the
+    /// appended guide token); `< 1.0` is reserved for future soft conditioning
+    /// and is rejected by `validateKeyframes()` until wired through.
     public let strength: Float
 
     public init(path: String, pixelFrameIndex: Int, strength: Float = 1.0) {
@@ -49,6 +47,10 @@ public struct KeyframeInput: Sendable, Equatable {
 /// LTX-2 latent layout: `output_frames = 8 * (latent_frames - 1) + 1`.
 /// - Pixel frame 0 maps to latent frame 0 (the standalone "+1" frame).
 /// - Pixel frames 1..8 map to latent frame 1, 9..16 to latent frame 2, etc.
+///
+/// With the appended-guide-token approach, the latent slot is informational only:
+/// each keyframe sits in its own appended token sequence with a RoPE temporal
+/// position of `(pixelFrameIndex + 0.5) / fps`, independent of slot collisions.
 public func pixelFrameToLatentFrame(_ pixelFrame: Int) -> Int {
     if pixelFrame <= 0 { return 0 }
     return (pixelFrame + 7) / 8
@@ -59,13 +61,13 @@ public func pixelFrameToLatentFrame(_ pixelFrame: Int) -> Int {
 /// Validate a list of keyframes against the target video configuration.
 ///
 /// Checks: file existence, frame indices in `[0, numFrames - 1]`, no duplicate
-/// pixel positions, no duplicate latent positions (since each latent slot can only
-/// hold one keyframe), strength in `(0, 1]`.
+/// pixel positions, strength == 1.0. Keyframes within the same latent stride
+/// group (e.g. pixel 8 and pixel 12 both mapping to latent slot 1) ARE allowed
+/// since the append path gives each its own RoPE temporal position.
 public func validateKeyframes(_ keyframes: [KeyframeInput], numFrames: Int) throws {
     guard !keyframes.isEmpty else { return }
 
     var seenPixelIndices = Set<Int>()
-    var seenLatentIndices = Set<Int>()
 
     for kf in keyframes {
         guard FileManager.default.fileExists(atPath: kf.path) else {
@@ -79,69 +81,13 @@ public func validateKeyframes(_ keyframes: [KeyframeInput], numFrames: Int) thro
         guard kf.strength == 1.0 else {
             throw LTXError.invalidConfiguration(
                 "Keyframe strength must be 1.0 (got \(kf.strength) for \(kf.path)). " +
-                "Soft conditioning (strength < 1.0) is not yet implemented; injection is hard."
+                "Soft conditioning (strength < 1.0) is not yet implemented."
             )
         }
         guard seenPixelIndices.insert(kf.pixelFrameIndex).inserted else {
             throw LTXError.invalidConfiguration(
                 "Duplicate keyframe at pixel frame \(kf.pixelFrameIndex)"
             )
-        }
-        let latentIdx = pixelFrameToLatentFrame(kf.pixelFrameIndex)
-        guard seenLatentIndices.insert(latentIdx).inserted else {
-            throw LTXError.invalidConfiguration(
-                "Multiple keyframes collide on latent frame \(latentIdx). " +
-                "Latent stride is 8 — keyframes within the same 8-frame group cannot coexist."
-            )
-        }
-    }
-}
-
-// MARK: - Mask & Injection Helpers
-
-/// Build a per-token conditioning mask. Tokens belonging to a keyframe latent frame
-/// get value `1.0`, all others get `0.0`. Output shape: `[1, shape.tokenCount]`.
-///
-/// The mask is consumed by the per-token timestep formula
-/// `videoTimestep = sigma * (1 - mask)` so that keyframe tokens are denoised with
-/// `σ = 0` (i.e. treated as clean references) while the rest follow the schedule.
-func buildKeyframeMask(latentIndices: [Int], shape: VideoLatentShape) -> MLXArray {
-    let tokensPerFrame = shape.height * shape.width
-    var maskValues = [Float](repeating: 0.0, count: shape.tokenCount)
-    for idx in latentIndices {
-        guard idx >= 0 && idx < shape.frames else { continue }
-        let start = idx * tokensPerFrame
-        for t in start..<(start + tokensPerFrame) {
-            maskValues[t] = 1.0
-        }
-    }
-    return MLXArray(maskValues, [1, shape.tokenCount])
-}
-
-/// Overwrite latent slots at each keyframe position with the encoded keyframe tensor.
-///
-/// When `sigma > 0` and `noiseScale > 0`, noise is added so the conditioned slot
-/// looks "realistic at the current schedule level" before the transformer pass.
-/// With defaults (`sigma = 0`, `noiseScale = 0`) the clean reference is restored —
-/// useful as a post-step re-injection that keeps keyframe slots pristine across
-/// the loop and into the final latent.
-///
-/// `latent` must have shape `(1, C, F, H, W)` and each `EncodedKeyframe.latent`
-/// must have shape `(1, C, 1, H, W)`.
-func injectKeyframeLatents(
-    into latent: inout MLXArray,
-    encoded: [EncodedKeyframe],
-    sigma: Float = 0.0,
-    noiseScale: Float = 0.0
-) {
-    for kf in encoded {
-        let slot = kf.latentIdx
-        if sigma > 0 && noiseScale > 0 {
-            let noise = MLXRandom.normal(kf.latent.shape)
-            let noised = kf.latent + MLXArray(noiseScale) * noise * MLXArray(sigma * sigma)
-            latent[0..., 0..., slot..<(slot + 1), 0..., 0...] = noised
-        } else {
-            latent[0..., 0..., slot..<(slot + 1), 0..., 0...] = kf.latent
         }
     }
 }

--- a/Sources/LTXVideo/Pipeline/LTXPipeline.swift
+++ b/Sources/LTXVideo/Pipeline/LTXPipeline.swift
@@ -571,6 +571,98 @@ public actor LTXPipeline {
         return unflattened.transposed(0, 2, 1, 3)
     }
 
+    // MARK: - Denoise step helper
+
+    /// Result of one denoise-loop forward pass: predicted velocities for the
+    /// video latent (always present) and the audio packed latent (when running
+    /// dual-stream `LTX2Transformer`). Both are unpatchified and float32 — ready
+    /// for the scheduler step. The video velocity has already been cropped back
+    /// to the original token count when `appendCtx` was provided.
+    private struct StepVelocity {
+        let video: MLXArray
+        let audio: MLXArray?
+    }
+
+    /// One forward pass through the active transformer (video-only `LTXTransformer`
+    /// or dual `LTX2Transformer`) at the given `sigma`. Handles the keyframe-append
+    /// path (extended tokens + per-token timestep + precomputed RoPE) when
+    /// `appendCtx` is non-nil, and the standard path otherwise.
+    ///
+    /// Caller is responsible for the scheduler step and post-step `MLX.eval`.
+    /// This split keeps the Stage 1 (Euler scheduler) and Stage 2 (manual Euler)
+    /// integration code untouched, since their numerical contracts differ.
+    private func runDenoiseStep(
+        sigma: Float,
+        videoLatent: MLXArray,
+        audioLatentPacked: MLXArray?,
+        shape: VideoLatentShape,
+        appendCtx: AppendKeyframeContext?,
+        audioNumFrames: Int,
+        videoTextEmbeddings: MLXArray,
+        audioTextEmbeddings: MLXArray,
+        textMask: MLXArray?
+    ) -> StepVelocity {
+        let videoPatchified = patchify(videoLatent).asType(.bfloat16)
+
+        let extTokensVideo: MLXArray
+        let videoTimestep: MLXArray
+        if let ctx = appendCtx {
+            extTokensVideo = MLX.concatenated([videoPatchified, ctx.guideTokens], axis: 1)
+            videoTimestep = buildExtendedTimestep(
+                sigma: sigma,
+                originalCount: ctx.originalCount,
+                guideCount: ctx.guideCount
+            )
+        } else {
+            extTokensVideo = videoPatchified
+            videoTimestep = MLXArray([sigma])
+        }
+
+        if let ltx2 = ltx2Transformer, let ap = audioLatentPacked {
+            let audioTimestep = MLXArray([sigma])
+            let audioPatchified = ap.asType(.bfloat16)
+            let (videoVelExt, audioVel) = ltx2(
+                videoLatent: extTokensVideo,
+                audioLatent: audioPatchified,
+                videoContext: videoTextEmbeddings.asType(.bfloat16),
+                audioContext: audioTextEmbeddings.asType(.bfloat16),
+                videoTimesteps: videoTimestep,
+                audioTimesteps: audioTimestep,
+                videoContextMask: textMask,
+                audioContextMask: nil,
+                videoLatentShape: (frames: shape.frames, height: shape.height, width: shape.width),
+                audioNumFrames: audioNumFrames,
+                precomputedVideoRoPE: appendCtx?.extRoPE,
+                precomputedCrossVideoRoPE: appendCtx?.extCrossVideoRoPE
+            )
+            let videoVel = appendCtx
+                .map { cropToOriginal(velocity: videoVelExt, originalCount: $0.originalCount) }
+                ?? videoVelExt
+            return StepVelocity(
+                video: unpatchify(videoVel, shape: shape).asType(.float32),
+                audio: audioVel.asType(.float32)
+            )
+        } else if let videoTransformer = transformer {
+            let velExt = videoTransformer(
+                latent: extTokensVideo,
+                context: videoTextEmbeddings.asType(.bfloat16),
+                timesteps: videoTimestep,
+                contextMask: nil,
+                latentShape: (frames: shape.frames, height: shape.height, width: shape.width),
+                precomputedRoPE: appendCtx?.extRoPE
+            )
+            let vel = appendCtx
+                .map { cropToOriginal(velocity: velExt, originalCount: $0.originalCount) }
+                ?? velExt
+            return StepVelocity(
+                video: unpatchify(vel, shape: shape).asType(.float32),
+                audio: nil
+            )
+        } else {
+            fatalError("runDenoiseStep called without any transformer loaded — guarded by generateVideo")
+        }
+    }
+
     // MARK: - Video Generation
 
     /// Generate video using two-stage pipeline (half-res → upscale → refine).
@@ -747,20 +839,18 @@ public actor LTXPipeline {
         // produced grainy artifacts at non-zero keyframe positions (issue #21) because
         // a 1-frame VAE encoding placed at a slot representing 8 pixel frames is
         // structurally incompatible with what the decoder expects.
-        let useAppendKeyframes = !halfResKeyframes.isEmpty
         MLX.eval(videoLatent)
 
         // Pre-build guide tokens, extended positions, and RoPE for the append path.
-        // These are constant across denoising steps, so compute once.
-        let stage1AppendCtx: AppendKeyframeContext? = useAppendKeyframes
-            ? prepareKeyframeAppend(
-                encoded: halfResKeyframes,
-                shape: stage1Shape,
-                hasAudio: hasAudio,
-                refConfig: transformer?.config ?? ltx2Transformer?.config ?? .default,
-                stageLabel: "Stage 1"
-            )
-            : nil
+        // These are constant across denoising steps, so compute once. Returns nil
+        // when there are no keyframes — `runDenoiseStep` handles both paths.
+        let stage1AppendCtx: AppendKeyframeContext? = prepareKeyframeAppend(
+            encoded: halfResKeyframes,
+            shape: stage1Shape,
+            hasAudio: hasAudio,
+            refConfig: transformer?.config ?? ltx2Transformer?.config ?? .default,
+            stageLabel: "Stage 1"
+        )
 
         // === STAGE 1: Denoise at half resolution ===
         let stage1NumSteps = stage1Sigmas.count - 1
@@ -780,116 +870,29 @@ public actor LTXPipeline {
                 currentStep: step, totalSteps: totalStepsForProgress, sigma: sigma, phase: .denoising
             ))
 
-            // Scalar timestep — keyframe conditioning is handled by appended guide
-            // tokens (per-token timestep extension built inside the append branch below).
-            let videoTimestep = MLXArray([sigma])
-
-            let videoPatchified = patchify(videoLatent).asType(.bfloat16)
-
-            if hasAudio, let ltx2 = ltx2Transformer, let ap = audioLatentPacked {
-                // Dual video/audio denoising
-                let audioTimestep = MLXArray([sigma])
-                let audioPatchified = ap.asType(.bfloat16)
-
-                if let ctx = stage1AppendCtx, let extCrossRoPE = ctx.extCrossVideoRoPE {
-                    let extTokens = MLX.concatenated([videoPatchified, ctx.guideTokens], axis: 1)
-                    let extTimestep = buildExtendedTimestep(
-                        sigma: sigma,
-                        originalCount: ctx.originalCount,
-                        guideCount: ctx.guideCount
-                    )
-                    let (videoVelPredExt, audioVelPred) = ltx2(
-                        videoLatent: extTokens,
-                        audioLatent: audioPatchified,
-                        videoContext: videoTextEmbeddings.asType(.bfloat16),
-                        audioContext: audioTextEmbeddings.asType(.bfloat16),
-                        videoTimesteps: extTimestep,
-                        audioTimesteps: audioTimestep,
-                        videoContextMask: textMask,
-                        audioContextMask: nil,
-                        videoLatentShape: (frames: stage1Shape.frames, height: stage1Shape.height, width: stage1Shape.width),
-                        audioNumFrames: audioNumFrames,
-                        precomputedVideoRoPE: ctx.extRoPE,
-                        precomputedCrossVideoRoPE: extCrossRoPE
-                    )
-                    let videoVelPred = cropToOriginal(velocity: videoVelPredExt, originalCount: ctx.originalCount)
-                    let videoVelocity = unpatchify(videoVelPred, shape: stage1Shape).asType(.float32)
-                    let audioVelocity = audioVelPred.asType(.float32)
-                    videoLatent = stage1Scheduler.step(
-                        latent: videoLatent, velocity: videoVelocity,
-                        sigma: sigma, sigmaNext: sigmaNext
-                    )
-                    let updatedAudio = ap + (sigmaNext - sigma) * audioVelocity
-                    audioLatentPacked = updatedAudio
-                    MLX.eval(videoLatent, updatedAudio)
-                } else {
-                    let (videoVelPred, audioVelPred) = ltx2(
-                        videoLatent: videoPatchified,
-                        audioLatent: audioPatchified,
-                        videoContext: videoTextEmbeddings.asType(.bfloat16),
-                        audioContext: audioTextEmbeddings.asType(.bfloat16),
-                        videoTimesteps: videoTimestep,
-                        audioTimesteps: audioTimestep,
-                        videoContextMask: textMask,
-                        audioContextMask: nil,
-                        videoLatentShape: (frames: stage1Shape.frames, height: stage1Shape.height, width: stage1Shape.width),
-                        audioNumFrames: audioNumFrames
-                    )
-
-                    let videoVelocity = unpatchify(videoVelPred, shape: stage1Shape).asType(.float32)
-                    let audioVelocity = audioVelPred.asType(.float32)
-
-                    videoLatent = stage1Scheduler.step(
-                        latent: videoLatent, velocity: videoVelocity,
-                        sigma: sigma, sigmaNext: sigmaNext
-                    )
-                    let updatedAudio = ap + (sigmaNext - sigma) * audioVelocity
-                    audioLatentPacked = updatedAudio
-                    MLX.eval(videoLatent, updatedAudio)
-                }
-            } else if let videoTransformer = transformer {
-                if let ctx = stage1AppendCtx {
-                    // Append guide tokens for keyframe conditioning (issue #21 fix).
-                    let extTokens = MLX.concatenated([videoPatchified, ctx.guideTokens], axis: 1)
-                    let extTimestep = buildExtendedTimestep(
-                        sigma: sigma,
-                        originalCount: ctx.originalCount,
-                        guideCount: ctx.guideCount
-                    )
-                    let velocityPredExt = videoTransformer(
-                        latent: extTokens,
-                        context: videoTextEmbeddings.asType(.bfloat16),
-                        timesteps: extTimestep,
-                        contextMask: nil,
-                        latentShape: (frames: stage1Shape.frames, height: stage1Shape.height, width: stage1Shape.width),
-                        precomputedRoPE: ctx.extRoPE
-                    )
-                    let velocityPred = cropToOriginal(velocity: velocityPredExt, originalCount: ctx.originalCount)
-                    let videoVelocity = unpatchify(velocityPred, shape: stage1Shape).asType(.float32)
-                    videoLatent = stage1Scheduler.step(
-                        latent: videoLatent, velocity: videoVelocity,
-                        sigma: sigma, sigmaNext: sigmaNext
-                    )
-                    // No re-injection: guide tokens carry the keyframe info via attention.
-                    MLX.eval(videoLatent)
-                } else {
-                    // T2V (no keyframes) — standard denoising
-                    let velocityPred = videoTransformer(
-                        latent: videoPatchified,
-                        context: videoTextEmbeddings.asType(.bfloat16),
-                        timesteps: videoTimestep,
-                        contextMask: nil,
-                        latentShape: (frames: stage1Shape.frames, height: stage1Shape.height, width: stage1Shape.width)
-                    )
-
-                    let videoVelocity = unpatchify(velocityPred, shape: stage1Shape).asType(.float32)
-
-                    videoLatent = stage1Scheduler.step(
-                        latent: videoLatent, velocity: videoVelocity,
-                        sigma: sigma, sigmaNext: sigmaNext
-                    )
-                    MLX.eval(videoLatent)
-                }
+            // One forward pass through the active transformer. Stage 1 uses the Euler
+            // scheduler for the video latent and a manual flow-matching update for audio.
+            let vel = runDenoiseStep(
+                sigma: sigma,
+                videoLatent: videoLatent,
+                audioLatentPacked: audioLatentPacked,
+                shape: stage1Shape,
+                appendCtx: stage1AppendCtx,
+                audioNumFrames: audioNumFrames,
+                videoTextEmbeddings: videoTextEmbeddings,
+                audioTextEmbeddings: audioTextEmbeddings,
+                textMask: textMask
+            )
+            videoLatent = stage1Scheduler.step(
+                latent: videoLatent, velocity: vel.video,
+                sigma: sigma, sigmaNext: sigmaNext
+            )
+            if let av = vel.audio, let ap = audioLatentPacked {
+                let updatedAudio = ap + (sigmaNext - sigma) * av
+                audioLatentPacked = updatedAudio
+                MLX.eval(videoLatent, updatedAudio)
+            } else {
+                MLX.eval(videoLatent)
             }
 
             if (step + 1) % 5 == 0 { Memory.clearCache() }
@@ -979,20 +982,17 @@ public actor LTXPipeline {
             fullResKeyframes = try await encodeKeyframes(effectiveKeyframes, width: config.width, height: config.height)
             unloadVAEEncoder()
         }
-        let useAppendKeyframesS2 = !fullResKeyframes.isEmpty
         MLX.eval(videoLatent)
         if hasAudio, let ap = audioLatentPacked { MLX.eval(ap) }
 
         // Pre-build guide tokens, extended positions, and RoPE for the Stage 2 append path.
-        let stage2AppendCtx: AppendKeyframeContext? = useAppendKeyframesS2
-            ? prepareKeyframeAppend(
-                encoded: fullResKeyframes,
-                shape: stage2Shape,
-                hasAudio: hasAudio,
-                refConfig: transformer?.config ?? ltx2Transformer?.config ?? .default,
-                stageLabel: "Stage 2"
-            )
-            : nil
+        let stage2AppendCtx: AppendKeyframeContext? = prepareKeyframeAppend(
+            encoded: fullResKeyframes,
+            shape: stage2Shape,
+            hasAudio: hasAudio,
+            refConfig: transformer?.config ?? ltx2Transformer?.config ?? .default,
+            stageLabel: "Stage 2"
+        )
 
         // Dump re-noised latent
         if LTXDebug.isEnabled {
@@ -1013,103 +1013,27 @@ public actor LTXPipeline {
                 currentStep: stage1NumSteps + step, totalSteps: totalStepsForProgress, sigma: sigma, phase: .refinement
             ))
 
-            // Scalar timestep — keyframe conditioning is handled by appended guide tokens
-            let videoTimestep = MLXArray([sigma])
-
-            let videoPatchified = patchify(videoLatent).asType(.bfloat16)
-
-            if hasAudio, let ltx2 = ltx2Transformer, let ap = audioLatentPacked {
-                let audioTimestep = MLXArray([sigma])
-                let audioPatchified = ap.asType(.bfloat16)
-
-                if let ctx = stage2AppendCtx, let extCrossRoPE = ctx.extCrossVideoRoPE {
-                    let extTokens = MLX.concatenated([videoPatchified, ctx.guideTokens], axis: 1)
-                    let extTimestep = buildExtendedTimestep(
-                        sigma: sigma,
-                        originalCount: ctx.originalCount,
-                        guideCount: ctx.guideCount
-                    )
-                    let (videoVelPredExt, audioVelPred) = ltx2(
-                        videoLatent: extTokens,
-                        audioLatent: audioPatchified,
-                        videoContext: videoTextEmbeddings.asType(.bfloat16),
-                        audioContext: audioTextEmbeddings.asType(.bfloat16),
-                        videoTimesteps: extTimestep,
-                        audioTimesteps: audioTimestep,
-                        videoContextMask: textMask,
-                        audioContextMask: nil,
-                        videoLatentShape: (frames: stage2Shape.frames, height: stage2Shape.height, width: stage2Shape.width),
-                        audioNumFrames: audioNumFrames,
-                        precomputedVideoRoPE: ctx.extRoPE,
-                        precomputedCrossVideoRoPE: extCrossRoPE
-                    )
-                    let videoVelPred = cropToOriginal(velocity: videoVelPredExt, originalCount: ctx.originalCount)
-                    let videoVelocity = unpatchify(videoVelPred, shape: stage2Shape).asType(.float32)
-                    let audioVelocity = audioVelPred.asType(.float32)
-                    let dt = sigmaNext - sigma
-                    videoLatent = videoLatent + MLXArray(dt) * videoVelocity
-                    let updatedAudio = ap + MLXArray(dt) * audioVelocity
-                    audioLatentPacked = updatedAudio
-                    MLX.eval(videoLatent, updatedAudio)
-                } else {
-                    let (videoVelPred, audioVelPred) = ltx2(
-                        videoLatent: videoPatchified,
-                        audioLatent: audioPatchified,
-                        videoContext: videoTextEmbeddings.asType(.bfloat16),
-                        audioContext: audioTextEmbeddings.asType(.bfloat16),
-                        videoTimesteps: videoTimestep,
-                        audioTimesteps: audioTimestep,
-                        videoContextMask: textMask,
-                        audioContextMask: nil,
-                        videoLatentShape: (frames: stage2Shape.frames, height: stage2Shape.height, width: stage2Shape.width),
-                        audioNumFrames: audioNumFrames
-                    )
-
-                    let videoVelocity = unpatchify(videoVelPred, shape: stage2Shape).asType(.float32)
-                    let audioVelocity = audioVelPred.asType(.float32)
-
-                    let dt = sigmaNext - sigma
-                    videoLatent = videoLatent + MLXArray(dt) * videoVelocity
-                    let updatedAudio = ap + MLXArray(dt) * audioVelocity
-                    audioLatentPacked = updatedAudio
-                    MLX.eval(videoLatent, updatedAudio)
-                }
-            } else if let videoTransformer = transformer {
-                if let ctx = stage2AppendCtx {
-                    let extTokens = MLX.concatenated([videoPatchified, ctx.guideTokens], axis: 1)
-                    let extTimestep = buildExtendedTimestep(
-                        sigma: sigma,
-                        originalCount: ctx.originalCount,
-                        guideCount: ctx.guideCount
-                    )
-                    let velocityPredExt = videoTransformer(
-                        latent: extTokens,
-                        context: videoTextEmbeddings.asType(.bfloat16),
-                        timesteps: extTimestep,
-                        contextMask: nil,
-                        latentShape: (frames: stage2Shape.frames, height: stage2Shape.height, width: stage2Shape.width),
-                        precomputedRoPE: ctx.extRoPE
-                    )
-                    let velocityPred = cropToOriginal(velocity: velocityPredExt, originalCount: ctx.originalCount)
-                    let videoVelocity = unpatchify(velocityPred, shape: stage2Shape).asType(.float32)
-                    let dt = sigmaNext - sigma
-                    videoLatent = videoLatent + MLXArray(dt) * videoVelocity
-                    MLX.eval(videoLatent)
-                } else {
-                    let velocityPred = videoTransformer(
-                        latent: videoPatchified,
-                        context: videoTextEmbeddings.asType(.bfloat16),
-                        timesteps: videoTimestep,
-                        contextMask: nil,
-                        latentShape: (frames: stage2Shape.frames, height: stage2Shape.height, width: stage2Shape.width)
-                    )
-
-                    let videoVelocity = unpatchify(velocityPred, shape: stage2Shape).asType(.float32)
-
-                    let dt = sigmaNext - sigma
-                    videoLatent = videoLatent + MLXArray(dt) * videoVelocity
-                    MLX.eval(videoLatent)
-                }
+            // One forward pass through the active transformer. Stage 2 uses a manual
+            // Euler step (not the Stage 1 scheduler) for both video and audio.
+            let vel = runDenoiseStep(
+                sigma: sigma,
+                videoLatent: videoLatent,
+                audioLatentPacked: audioLatentPacked,
+                shape: stage2Shape,
+                appendCtx: stage2AppendCtx,
+                audioNumFrames: audioNumFrames,
+                videoTextEmbeddings: videoTextEmbeddings,
+                audioTextEmbeddings: audioTextEmbeddings,
+                textMask: textMask
+            )
+            let dt = sigmaNext - sigma
+            videoLatent = videoLatent + MLXArray(dt) * vel.video
+            if let av = vel.audio, let ap = audioLatentPacked {
+                let updatedAudio = ap + MLXArray(dt) * av
+                audioLatentPacked = updatedAudio
+                MLX.eval(videoLatent, updatedAudio)
+            } else {
+                MLX.eval(videoLatent)
             }
 
             let stepDur2 = Date().timeIntervalSince(stepStart)

--- a/Sources/LTXVideo/Pipeline/LTXPipeline.swift
+++ b/Sources/LTXVideo/Pipeline/LTXPipeline.swift
@@ -736,41 +736,28 @@ public actor LTXPipeline {
             audioLatentPacked = ap * stage1Sigmas[0]
         }
 
-        // [PROTOTYPE issue #21] Env-var gate to switch keyframe handling from
-        // hard-injection to appended guide tokens with shifted RoPE positions.
-        // When LTX_KEYFRAME_APPEND=1, the keyframe latents stay separate from the
-        // main video sequence; they're concatenated as extra tokens with their own
-        // temporal/spatial positions and σ=0 timestep. The model "sees" them via
-        // attention, and we crop the predicted velocity to the original token count
-        // before the scheduler step. This matches Lightricks `VideoConditionByKeyframeIndex`.
+        // Keyframe conditioning (issue #21 fix): appended guide tokens with shifted RoPE
+        // positions, matching Lightricks `VideoConditionByKeyframeIndex` semantics.
+        //
+        // The keyframe latents stay separate from the main video sequence; they're
+        // concatenated as extra tokens with their own temporal/spatial positions and
+        // σ=0 timestep. The model "sees" them via attention, and we crop the predicted
+        // velocity to the original token count before the scheduler step. This is the
+        // only keyframe code path — the previous "inject into latent slot" approach
+        // produced grainy artifacts at non-zero keyframe positions (issue #21) because
+        // a 1-frame VAE encoding placed at a slot representing 8 pixel frames is
+        // structurally incompatible with what the decoder expects.
         let useAppendKeyframes = !halfResKeyframes.isEmpty
-            && ProcessInfo.processInfo.environment["LTX_KEYFRAME_APPEND"] == "1"
-            && transformer != nil
-            && !hasAudio
-        let stopAfterStage1 = ProcessInfo.processInfo.environment["LTX_STOP_AFTER_STAGE1"] == "1"
-        if useAppendKeyframes {
-            LTXDebug.log("[PROTO] Using APPEND keyframe mode (\(halfResKeyframes.count) keyframes)")
-        }
-
-        // I2V: inject keyframe latents and build per-token conditioning mask
-        // (legacy path — skipped when useAppendKeyframes is true)
-        var stage1CondMask: MLXArray? = nil
-        if !halfResKeyframes.isEmpty && !useAppendKeyframes {
-            injectKeyframeLatents(into: &videoLatent, encoded: halfResKeyframes)
-            let slots = halfResKeyframes.map { $0.latentIdx }
-            let mask = buildKeyframeMask(latentIndices: slots, shape: stage1Shape)
-            MLX.eval(mask)
-            stage1CondMask = mask
-        }
         MLX.eval(videoLatent)
 
         // [PROTOTYPE] Pre-build guide tokens, extended positions, and RoPE for append path.
         // These are constant across denoising steps, so compute once.
         var appendGuideTokens: MLXArray? = nil
         var appendExtRoPE: (cos: MLXArray, sin: MLXArray)? = nil
+        var appendExtCrossVideoRoPE: (cos: MLXArray, sin: MLXArray)? = nil
         var appendOriginalCount: Int = 0
         var appendGuideCount: Int = 0
-        if useAppendKeyframes, let videoTransformer = transformer {
+        if useAppendKeyframes {
             let basePos = buildBaseVideoPositions(
                 batchSize: 1,
                 frames: stage1Shape.frames,
@@ -784,8 +771,6 @@ public actor LTXPipeline {
                     fps: 24.0
                 )
             }
-
-            // Sanity: collect guide token count & build dummy guide-only token block for shape only
             let allGuideTokens = MLX.concatenated(guides.map { $0.tokens }, axis: 1)
             let allGuidePositions = MLX.concatenated(guides.map { $0.positions }, axis: 2)
             appendGuideTokens = allGuideTokens
@@ -794,20 +779,46 @@ public actor LTXPipeline {
 
             let extPositions = MLX.concatenated([basePos, allGuidePositions], axis: 2)
 
-            // Pre-compute RoPE for extended positions
+            // Pick the relevant transformer config (video-only or dual stream)
+            let refConfig: LTXTransformerConfig
+            if let videoTransformer = transformer {
+                refConfig = videoTransformer.config
+            } else if let dual = ltx2Transformer {
+                refConfig = dual.config
+            } else {
+                refConfig = .default
+            }
+
+            // Pre-compute RoPE for extended positions (used by both LTXTransformer and
+            // LTX2Transformer's video stream)
             let pe = precomputeFreqsCis(
                 indicesGrid: extPositions,
-                dim: videoTransformer.config.innerDim,
-                theta: videoTransformer.config.ropeTheta,
-                maxPos: videoTransformer.config.maxPos,
-                numAttentionHeads: videoTransformer.config.numAttentionHeads,
+                dim: refConfig.innerDim,
+                theta: refConfig.ropeTheta,
+                maxPos: refConfig.maxPos,
+                numAttentionHeads: refConfig.numAttentionHeads,
                 ropeType: .split,
                 doublePrecision: true
             )
             MLX.eval(pe.cos, pe.sin)
             appendExtRoPE = pe
-            LTXDebug.log("[PROTO] extended sequence: \(appendOriginalCount) video + \(appendGuideCount) guide = \(appendOriginalCount + appendGuideCount) tokens")
-            LTXDebug.log("[PROTO] extended RoPE shape: cos=\(pe.cos.shape) sin=\(pe.sin.shape)")
+
+            // Cross-modal video RoPE (audio path only): temporal-only coords from extPositions
+            if hasAudio {
+                let temporalOnly = extPositions[0..., 0..<1, 0...]
+                let crossPE = precomputeFreqsCis(
+                    indicesGrid: temporalOnly,
+                    dim: refConfig.audioCrossAttentionDim,
+                    theta: refConfig.ropeTheta,
+                    maxPos: refConfig.audioMaxPos,
+                    numAttentionHeads: refConfig.audioNumAttentionHeads,
+                    ropeType: .split,
+                    doublePrecision: true
+                )
+                MLX.eval(crossPE.cos, crossPE.sin)
+                appendExtCrossVideoRoPE = crossPE
+            }
+            LTXDebug.log("[append] Stage 1 extended sequence: \(appendOriginalCount) video + \(appendGuideCount) guide tokens")
         }
 
         // === STAGE 1: Denoise at half resolution ===
@@ -828,22 +839,9 @@ public actor LTXPipeline {
                 currentStep: step, totalSteps: totalStepsForProgress, sigma: sigma, phase: .denoising
             ))
 
-            // Pre-step: re-inject keyframes (with optional noise scaled by current sigma)
-            // so the transformer sees them at the right schedule level.
-            if !halfResKeyframes.isEmpty && config.imageCondNoiseScale > 0 && sigma > 0 {
-                injectKeyframeLatents(
-                    into: &videoLatent, encoded: halfResKeyframes,
-                    sigma: sigma, noiseScale: config.imageCondNoiseScale
-                )
-            }
-
-            // Per-token timestep: keyframe slots get σ=0, others get σ
-            let videoTimestep: MLXArray
-            if let mask = stage1CondMask {
-                videoTimestep = MLXArray(sigma) * (1 - mask)
-            } else {
-                videoTimestep = MLXArray([sigma])
-            }
+            // Scalar timestep — keyframe conditioning is handled by appended guide
+            // tokens (per-token timestep extension built inside the append branch below).
+            let videoTimestep = MLXArray([sigma])
 
             let videoPatchified = patchify(videoLatent).asType(.bfloat16)
 
@@ -852,39 +850,70 @@ public actor LTXPipeline {
                 let audioTimestep = MLXArray([sigma])
                 let audioPatchified = ap.asType(.bfloat16)
 
-                let (videoVelPred, audioVelPred) = ltx2(
-                    videoLatent: videoPatchified,
-                    audioLatent: audioPatchified,
-                    videoContext: videoTextEmbeddings.asType(.bfloat16),
-                    audioContext: audioTextEmbeddings.asType(.bfloat16),
-                    videoTimesteps: videoTimestep,
-                    audioTimesteps: audioTimestep,
-                    videoContextMask: textMask,
-                    audioContextMask: nil,
-                    videoLatentShape: (frames: stage1Shape.frames, height: stage1Shape.height, width: stage1Shape.width),
-                    audioNumFrames: audioNumFrames
-                )
+                if useAppendKeyframes,
+                   let guideTokens = appendGuideTokens,
+                   let extRoPE = appendExtRoPE,
+                   let extCrossRoPE = appendExtCrossVideoRoPE {
+                    let extTokens = MLX.concatenated([videoPatchified, guideTokens], axis: 1)
+                    let extTimestep = buildExtendedTimestep(
+                        sigma: sigma,
+                        originalCount: appendOriginalCount,
+                        guideCount: appendGuideCount
+                    )
+                    let (videoVelPredExt, audioVelPred) = ltx2(
+                        videoLatent: extTokens,
+                        audioLatent: audioPatchified,
+                        videoContext: videoTextEmbeddings.asType(.bfloat16),
+                        audioContext: audioTextEmbeddings.asType(.bfloat16),
+                        videoTimesteps: extTimestep,
+                        audioTimesteps: audioTimestep,
+                        videoContextMask: textMask,
+                        audioContextMask: nil,
+                        videoLatentShape: (frames: stage1Shape.frames, height: stage1Shape.height, width: stage1Shape.width),
+                        audioNumFrames: audioNumFrames,
+                        precomputedVideoRoPE: extRoPE,
+                        precomputedCrossVideoRoPE: extCrossRoPE
+                    )
+                    let videoVelPred = cropToOriginal(velocity: videoVelPredExt, originalCount: appendOriginalCount)
+                    let videoVelocity = unpatchify(videoVelPred, shape: stage1Shape).asType(.float32)
+                    let audioVelocity = audioVelPred.asType(.float32)
+                    videoLatent = stage1Scheduler.step(
+                        latent: videoLatent, velocity: videoVelocity,
+                        sigma: sigma, sigmaNext: sigmaNext
+                    )
+                    let updatedAudio = ap + (sigmaNext - sigma) * audioVelocity
+                    audioLatentPacked = updatedAudio
+                    MLX.eval(videoLatent, updatedAudio)
+                } else {
+                    let (videoVelPred, audioVelPred) = ltx2(
+                        videoLatent: videoPatchified,
+                        audioLatent: audioPatchified,
+                        videoContext: videoTextEmbeddings.asType(.bfloat16),
+                        audioContext: audioTextEmbeddings.asType(.bfloat16),
+                        videoTimesteps: videoTimestep,
+                        audioTimesteps: audioTimestep,
+                        videoContextMask: textMask,
+                        audioContextMask: nil,
+                        videoLatentShape: (frames: stage1Shape.frames, height: stage1Shape.height, width: stage1Shape.width),
+                        audioNumFrames: audioNumFrames
+                    )
 
-                let videoVelocity = unpatchify(videoVelPred, shape: stage1Shape).asType(.float32)
-                let audioVelocity = audioVelPred.asType(.float32)
+                    let videoVelocity = unpatchify(videoVelPred, shape: stage1Shape).asType(.float32)
+                    let audioVelocity = audioVelPred.asType(.float32)
 
-                videoLatent = stage1Scheduler.step(
-                    latent: videoLatent, velocity: videoVelocity,
-                    sigma: sigma, sigmaNext: sigmaNext
-                )
-                // Restore keyframe slots (clean references) — overwrites the wrong update
-                // applied by the scalar-sigma scheduler at those positions.
-                if !halfResKeyframes.isEmpty {
-                    injectKeyframeLatents(into: &videoLatent, encoded: halfResKeyframes)
+                    videoLatent = stage1Scheduler.step(
+                        latent: videoLatent, velocity: videoVelocity,
+                        sigma: sigma, sigmaNext: sigmaNext
+                    )
+                    let updatedAudio = ap + (sigmaNext - sigma) * audioVelocity
+                    audioLatentPacked = updatedAudio
+                    MLX.eval(videoLatent, updatedAudio)
                 }
-                let updatedAudio = ap + (sigmaNext - sigma) * audioVelocity
-                audioLatentPacked = updatedAudio
-                MLX.eval(videoLatent, updatedAudio)
             } else if let videoTransformer = transformer {
                 if useAppendKeyframes,
                    let guideTokens = appendGuideTokens,
                    let extRoPE = appendExtRoPE {
-                    // [PROTOTYPE] Append guide tokens for keyframe conditioning.
+                    // Append guide tokens for keyframe conditioning (issue #21 fix).
                     let extTokens = MLX.concatenated([videoPatchified, guideTokens], axis: 1)
                     let extTimestep = buildExtendedTimestep(
                         sigma: sigma,
@@ -908,7 +937,7 @@ public actor LTXPipeline {
                     // No re-injection: guide tokens carry the keyframe info via attention.
                     MLX.eval(videoLatent)
                 } else {
-                    // Video-only denoising (legacy path)
+                    // T2V (no keyframes) — standard denoising
                     let velocityPred = videoTransformer(
                         latent: videoPatchified,
                         context: videoTextEmbeddings.asType(.bfloat16),
@@ -923,9 +952,6 @@ public actor LTXPipeline {
                         latent: videoLatent, velocity: videoVelocity,
                         sigma: sigma, sigmaNext: sigmaNext
                     )
-                    if !halfResKeyframes.isEmpty {
-                        injectKeyframeLatents(into: &videoLatent, encoded: halfResKeyframes)
-                    }
                     MLX.eval(videoLatent)
                 }
             }
@@ -949,40 +975,6 @@ public actor LTXPipeline {
         }
 
         profiler.end("Denoising Stage 1")
-
-        // [PROTOTYPE] Early-exit hook for M1/M2/M3 measurement. Decodes the Stage 1
-        // half-res latent and returns it as the video result, bypassing upscale + Stage 2.
-        if stopAfterStage1 {
-            LTXDebug.log("[PROTO] LTX_STOP_AFTER_STAGE1=1 — decoding Stage 1 latent and exiting")
-            if let dumpPath = ProcessInfo.processInfo.environment["LTX_DUMP_FINAL_LATENT"] {
-                let l32 = videoLatent.asType(.float32)
-                MLX.eval(l32)
-                try? MLX.save(arrays: ["data": l32], url: URL(fileURLWithPath: dumpPath))
-                LTXDebug.log("[PROTO] dumped stage-1 latent to \(dumpPath): \(l32.shape)")
-            }
-            LTXMemoryManager.setPhase(.vaeDecode)
-            let stage1Decoded = decodeVideo(
-                latent: videoLatent, decoder: vaeDecoder, timestep: nil,
-                temporalTileSize: memoryOptimization.vaeTemporalTileSize,
-                temporalTileOverlap: memoryOptimization.vaeTemporalTileOverlap
-            )
-            MLX.eval(stage1Decoded)
-            let trimmed: MLXArray
-            if stage1Decoded.dim(0) > config.numFrames {
-                trimmed = stage1Decoded[0..<config.numFrames]
-            } else {
-                trimmed = stage1Decoded
-            }
-            let gen = Date().timeIntervalSince(generationStart)
-            return VideoGenerationResult(
-                frames: trimmed,
-                seed: config.seed ?? 0,
-                generationTime: gen,
-                audioWaveform: nil,
-                audioSampleRate: nil,
-                effectivePrompt: effectivePrompt
-            )
-        }
 
         // === UPSCALE VIDEO 2x (audio unchanged) ===
         onProgress?(GenerationProgress(
@@ -1044,31 +1036,24 @@ public actor LTXPipeline {
             audioLatentPacked = MLXArray(noiseScale) * audioReNoise + MLXArray(1.0 - noiseScale) * ap
         }
 
-        // I2V stage 2: encode keyframes at full resolution and inject
+        // I2V stage 2: encode keyframes at full resolution
         var fullResKeyframes: [EncodedKeyframe] = []
-        var stage2CondMask: MLXArray? = nil
-        let useAppendKeyframesS2 = useAppendKeyframes  // same env-var gate
         if isI2V {
             LTXDebug.log("Stage 2: encoding \(effectiveKeyframes.count) keyframe(s) at \(config.width)x\(config.height)")
             fullResKeyframes = try await encodeKeyframes(effectiveKeyframes, width: config.width, height: config.height)
             unloadVAEEncoder()
-            if !useAppendKeyframesS2 {
-                injectKeyframeLatents(into: &videoLatent, encoded: fullResKeyframes)
-                let slots = fullResKeyframes.map { $0.latentIdx }
-                let mask = buildKeyframeMask(latentIndices: slots, shape: stage2Shape)
-                MLX.eval(mask)
-                stage2CondMask = mask
-            }
         }
+        let useAppendKeyframesS2 = !fullResKeyframes.isEmpty
         MLX.eval(videoLatent)
         if hasAudio, let ap = audioLatentPacked { MLX.eval(ap) }
 
-        // [PROTOTYPE] Stage 2 append: pre-build guides + extended positions + RoPE
+        // [append] Stage 2 append: pre-build guides + extended positions + RoPE
         var appendGuideTokensS2: MLXArray? = nil
         var appendExtRoPES2: (cos: MLXArray, sin: MLXArray)? = nil
+        var appendExtCrossVideoRoPES2: (cos: MLXArray, sin: MLXArray)? = nil
         var appendOriginalCountS2: Int = 0
         var appendGuideCountS2: Int = 0
-        if useAppendKeyframesS2, let videoTransformer = transformer, !fullResKeyframes.isEmpty {
+        if useAppendKeyframesS2, !fullResKeyframes.isEmpty {
             let basePos = buildBaseVideoPositions(
                 batchSize: 1,
                 frames: stage2Shape.frames,
@@ -1088,18 +1073,43 @@ public actor LTXPipeline {
             appendGuideCountS2 = allGuideTokens.dim(1)
             appendOriginalCountS2 = stage2Shape.tokenCount
             let extPositions = MLX.concatenated([basePos, allGuidePositions], axis: 2)
+
+            let refConfig: LTXTransformerConfig
+            if let videoTransformer = transformer {
+                refConfig = videoTransformer.config
+            } else if let dual = ltx2Transformer {
+                refConfig = dual.config
+            } else {
+                refConfig = .default
+            }
+
             let pe = precomputeFreqsCis(
                 indicesGrid: extPositions,
-                dim: videoTransformer.config.innerDim,
-                theta: videoTransformer.config.ropeTheta,
-                maxPos: videoTransformer.config.maxPos,
-                numAttentionHeads: videoTransformer.config.numAttentionHeads,
+                dim: refConfig.innerDim,
+                theta: refConfig.ropeTheta,
+                maxPos: refConfig.maxPos,
+                numAttentionHeads: refConfig.numAttentionHeads,
                 ropeType: .split,
                 doublePrecision: true
             )
             MLX.eval(pe.cos, pe.sin)
             appendExtRoPES2 = pe
-            LTXDebug.log("[PROTO Stage 2] extended sequence: \(appendOriginalCountS2) video + \(appendGuideCountS2) guide = \(appendOriginalCountS2 + appendGuideCountS2) tokens")
+
+            if hasAudio {
+                let temporalOnly = extPositions[0..., 0..<1, 0...]
+                let crossPE = precomputeFreqsCis(
+                    indicesGrid: temporalOnly,
+                    dim: refConfig.audioCrossAttentionDim,
+                    theta: refConfig.ropeTheta,
+                    maxPos: refConfig.audioMaxPos,
+                    numAttentionHeads: refConfig.audioNumAttentionHeads,
+                    ropeType: .split,
+                    doublePrecision: true
+                )
+                MLX.eval(crossPE.cos, crossPE.sin)
+                appendExtCrossVideoRoPES2 = crossPE
+            }
+            LTXDebug.log("[append] Stage 2 extended sequence: \(appendOriginalCountS2) video + \(appendGuideCountS2) guide tokens")
         }
 
         // Dump re-noised latent
@@ -1121,21 +1131,8 @@ public actor LTXPipeline {
                 currentStep: stage1NumSteps + step, totalSteps: totalStepsForProgress, sigma: sigma, phase: .refinement
             ))
 
-            // Pre-step: re-inject keyframes with noise scaled by current sigma
-            if !fullResKeyframes.isEmpty && config.imageCondNoiseScale > 0 && sigma > 0 {
-                injectKeyframeLatents(
-                    into: &videoLatent, encoded: fullResKeyframes,
-                    sigma: sigma, noiseScale: config.imageCondNoiseScale
-                )
-            }
-
-            // Per-token timestep: keyframe slots get σ=0, others get σ
-            let videoTimestep: MLXArray
-            if let mask = stage2CondMask {
-                videoTimestep = MLXArray(sigma) * (1 - mask)
-            } else {
-                videoTimestep = MLXArray([sigma])
-            }
+            // Scalar timestep — keyframe conditioning is handled by appended guide tokens
+            let videoTimestep = MLXArray([sigma])
 
             let videoPatchified = patchify(videoLatent).asType(.bfloat16)
 
@@ -1143,30 +1140,61 @@ public actor LTXPipeline {
                 let audioTimestep = MLXArray([sigma])
                 let audioPatchified = ap.asType(.bfloat16)
 
-                let (videoVelPred, audioVelPred) = ltx2(
-                    videoLatent: videoPatchified,
-                    audioLatent: audioPatchified,
-                    videoContext: videoTextEmbeddings.asType(.bfloat16),
-                    audioContext: audioTextEmbeddings.asType(.bfloat16),
-                    videoTimesteps: videoTimestep,
-                    audioTimesteps: audioTimestep,
-                    videoContextMask: textMask,
-                    audioContextMask: nil,
-                    videoLatentShape: (frames: stage2Shape.frames, height: stage2Shape.height, width: stage2Shape.width),
-                    audioNumFrames: audioNumFrames
-                )
+                if useAppendKeyframesS2,
+                   let guideTokens = appendGuideTokensS2,
+                   let extRoPE = appendExtRoPES2,
+                   let extCrossRoPE = appendExtCrossVideoRoPES2 {
+                    let extTokens = MLX.concatenated([videoPatchified, guideTokens], axis: 1)
+                    let extTimestep = buildExtendedTimestep(
+                        sigma: sigma,
+                        originalCount: appendOriginalCountS2,
+                        guideCount: appendGuideCountS2
+                    )
+                    let (videoVelPredExt, audioVelPred) = ltx2(
+                        videoLatent: extTokens,
+                        audioLatent: audioPatchified,
+                        videoContext: videoTextEmbeddings.asType(.bfloat16),
+                        audioContext: audioTextEmbeddings.asType(.bfloat16),
+                        videoTimesteps: extTimestep,
+                        audioTimesteps: audioTimestep,
+                        videoContextMask: textMask,
+                        audioContextMask: nil,
+                        videoLatentShape: (frames: stage2Shape.frames, height: stage2Shape.height, width: stage2Shape.width),
+                        audioNumFrames: audioNumFrames,
+                        precomputedVideoRoPE: extRoPE,
+                        precomputedCrossVideoRoPE: extCrossRoPE
+                    )
+                    let videoVelPred = cropToOriginal(velocity: videoVelPredExt, originalCount: appendOriginalCountS2)
+                    let videoVelocity = unpatchify(videoVelPred, shape: stage2Shape).asType(.float32)
+                    let audioVelocity = audioVelPred.asType(.float32)
+                    let dt = sigmaNext - sigma
+                    videoLatent = videoLatent + MLXArray(dt) * videoVelocity
+                    let updatedAudio = ap + MLXArray(dt) * audioVelocity
+                    audioLatentPacked = updatedAudio
+                    MLX.eval(videoLatent, updatedAudio)
+                } else {
+                    let (videoVelPred, audioVelPred) = ltx2(
+                        videoLatent: videoPatchified,
+                        audioLatent: audioPatchified,
+                        videoContext: videoTextEmbeddings.asType(.bfloat16),
+                        audioContext: audioTextEmbeddings.asType(.bfloat16),
+                        videoTimesteps: videoTimestep,
+                        audioTimesteps: audioTimestep,
+                        videoContextMask: textMask,
+                        audioContextMask: nil,
+                        videoLatentShape: (frames: stage2Shape.frames, height: stage2Shape.height, width: stage2Shape.width),
+                        audioNumFrames: audioNumFrames
+                    )
 
-                let videoVelocity = unpatchify(videoVelPred, shape: stage2Shape).asType(.float32)
-                let audioVelocity = audioVelPred.asType(.float32)
+                    let videoVelocity = unpatchify(videoVelPred, shape: stage2Shape).asType(.float32)
+                    let audioVelocity = audioVelPred.asType(.float32)
 
-                let dt = sigmaNext - sigma
-                videoLatent = videoLatent + MLXArray(dt) * videoVelocity
-                if !fullResKeyframes.isEmpty {
-                    injectKeyframeLatents(into: &videoLatent, encoded: fullResKeyframes)
+                    let dt = sigmaNext - sigma
+                    videoLatent = videoLatent + MLXArray(dt) * videoVelocity
+                    let updatedAudio = ap + MLXArray(dt) * audioVelocity
+                    audioLatentPacked = updatedAudio
+                    MLX.eval(videoLatent, updatedAudio)
                 }
-                let updatedAudio = ap + MLXArray(dt) * audioVelocity
-                audioLatentPacked = updatedAudio
-                MLX.eval(videoLatent, updatedAudio)
             } else if let videoTransformer = transformer {
                 if useAppendKeyframesS2,
                    let guideTokens = appendGuideTokensS2,
@@ -1203,9 +1231,6 @@ public actor LTXPipeline {
 
                     let dt = sigmaNext - sigma
                     videoLatent = videoLatent + MLXArray(dt) * videoVelocity
-                    if !fullResKeyframes.isEmpty {
-                        injectKeyframeLatents(into: &videoLatent, encoded: fullResKeyframes)
-                    }
                     MLX.eval(videoLatent)
                 }
             }

--- a/Sources/LTXVideo/Pipeline/LTXPipeline.swift
+++ b/Sources/LTXVideo/Pipeline/LTXPipeline.swift
@@ -750,7 +750,7 @@ public actor LTXPipeline {
         let useAppendKeyframes = !halfResKeyframes.isEmpty
         MLX.eval(videoLatent)
 
-        // [PROTOTYPE] Pre-build guide tokens, extended positions, and RoPE for append path.
+        // Pre-build guide tokens, extended positions, and RoPE for the append path.
         // These are constant across denoising steps, so compute once.
         var appendGuideTokens: MLXArray? = nil
         var appendExtRoPE: (cos: MLXArray, sin: MLXArray)? = nil
@@ -758,7 +758,7 @@ public actor LTXPipeline {
         var appendOriginalCount: Int = 0
         var appendGuideCount: Int = 0
         if useAppendKeyframes {
-            let basePos = buildBaseVideoPositions(
+            let basePos = createPositionGrid(
                 batchSize: 1,
                 frames: stage1Shape.frames,
                 height: stage1Shape.height,
@@ -1054,7 +1054,7 @@ public actor LTXPipeline {
         var appendOriginalCountS2: Int = 0
         var appendGuideCountS2: Int = 0
         if useAppendKeyframesS2, !fullResKeyframes.isEmpty {
-            let basePos = buildBaseVideoPositions(
+            let basePos = createPositionGrid(
                 batchSize: 1,
                 frames: stage2Shape.frames,
                 height: stage2Shape.height,

--- a/Sources/LTXVideo/Pipeline/LTXPipeline.swift
+++ b/Sources/LTXVideo/Pipeline/LTXPipeline.swift
@@ -736,9 +736,26 @@ public actor LTXPipeline {
             audioLatentPacked = ap * stage1Sigmas[0]
         }
 
+        // [PROTOTYPE issue #21] Env-var gate to switch keyframe handling from
+        // hard-injection to appended guide tokens with shifted RoPE positions.
+        // When LTX_KEYFRAME_APPEND=1, the keyframe latents stay separate from the
+        // main video sequence; they're concatenated as extra tokens with their own
+        // temporal/spatial positions and σ=0 timestep. The model "sees" them via
+        // attention, and we crop the predicted velocity to the original token count
+        // before the scheduler step. This matches Lightricks `VideoConditionByKeyframeIndex`.
+        let useAppendKeyframes = !halfResKeyframes.isEmpty
+            && ProcessInfo.processInfo.environment["LTX_KEYFRAME_APPEND"] == "1"
+            && transformer != nil
+            && !hasAudio
+        let stopAfterStage1 = ProcessInfo.processInfo.environment["LTX_STOP_AFTER_STAGE1"] == "1"
+        if useAppendKeyframes {
+            LTXDebug.log("[PROTO] Using APPEND keyframe mode (\(halfResKeyframes.count) keyframes)")
+        }
+
         // I2V: inject keyframe latents and build per-token conditioning mask
+        // (legacy path — skipped when useAppendKeyframes is true)
         var stage1CondMask: MLXArray? = nil
-        if !halfResKeyframes.isEmpty {
+        if !halfResKeyframes.isEmpty && !useAppendKeyframes {
             injectKeyframeLatents(into: &videoLatent, encoded: halfResKeyframes)
             let slots = halfResKeyframes.map { $0.latentIdx }
             let mask = buildKeyframeMask(latentIndices: slots, shape: stage1Shape)
@@ -746,6 +763,52 @@ public actor LTXPipeline {
             stage1CondMask = mask
         }
         MLX.eval(videoLatent)
+
+        // [PROTOTYPE] Pre-build guide tokens, extended positions, and RoPE for append path.
+        // These are constant across denoising steps, so compute once.
+        var appendGuideTokens: MLXArray? = nil
+        var appendExtRoPE: (cos: MLXArray, sin: MLXArray)? = nil
+        var appendOriginalCount: Int = 0
+        var appendGuideCount: Int = 0
+        if useAppendKeyframes, let videoTransformer = transformer {
+            let basePos = buildBaseVideoPositions(
+                batchSize: 1,
+                frames: stage1Shape.frames,
+                height: stage1Shape.height,
+                width: stage1Shape.width
+            )
+            let guides = halfResKeyframes.map { kf -> AppendedGuideTokens in
+                buildKeyframeGuideToken(
+                    encodedLatent: kf.latent,
+                    pixelFrameIndex: kf.pixelFrameIndex,
+                    fps: 24.0
+                )
+            }
+
+            // Sanity: collect guide token count & build dummy guide-only token block for shape only
+            let allGuideTokens = MLX.concatenated(guides.map { $0.tokens }, axis: 1)
+            let allGuidePositions = MLX.concatenated(guides.map { $0.positions }, axis: 2)
+            appendGuideTokens = allGuideTokens
+            appendGuideCount = allGuideTokens.dim(1)
+            appendOriginalCount = stage1Shape.tokenCount
+
+            let extPositions = MLX.concatenated([basePos, allGuidePositions], axis: 2)
+
+            // Pre-compute RoPE for extended positions
+            let pe = precomputeFreqsCis(
+                indicesGrid: extPositions,
+                dim: videoTransformer.config.innerDim,
+                theta: videoTransformer.config.ropeTheta,
+                maxPos: videoTransformer.config.maxPos,
+                numAttentionHeads: videoTransformer.config.numAttentionHeads,
+                ropeType: .split,
+                doublePrecision: true
+            )
+            MLX.eval(pe.cos, pe.sin)
+            appendExtRoPE = pe
+            LTXDebug.log("[PROTO] extended sequence: \(appendOriginalCount) video + \(appendGuideCount) guide = \(appendOriginalCount + appendGuideCount) tokens")
+            LTXDebug.log("[PROTO] extended RoPE shape: cos=\(pe.cos.shape) sin=\(pe.sin.shape)")
+        }
 
         // === STAGE 1: Denoise at half resolution ===
         let stage1NumSteps = stage1Sigmas.count - 1
@@ -818,25 +881,53 @@ public actor LTXPipeline {
                 audioLatentPacked = updatedAudio
                 MLX.eval(videoLatent, updatedAudio)
             } else if let videoTransformer = transformer {
-                // Video-only denoising
-                let velocityPred = videoTransformer(
-                    latent: videoPatchified,
-                    context: videoTextEmbeddings.asType(.bfloat16),
-                    timesteps: videoTimestep,
-                    contextMask: nil,
-                    latentShape: (frames: stage1Shape.frames, height: stage1Shape.height, width: stage1Shape.width)
-                )
+                if useAppendKeyframes,
+                   let guideTokens = appendGuideTokens,
+                   let extRoPE = appendExtRoPE {
+                    // [PROTOTYPE] Append guide tokens for keyframe conditioning.
+                    let extTokens = MLX.concatenated([videoPatchified, guideTokens], axis: 1)
+                    let extTimestep = buildExtendedTimestep(
+                        sigma: sigma,
+                        originalCount: appendOriginalCount,
+                        guideCount: appendGuideCount
+                    )
+                    let velocityPredExt = videoTransformer(
+                        latent: extTokens,
+                        context: videoTextEmbeddings.asType(.bfloat16),
+                        timesteps: extTimestep,
+                        contextMask: nil,
+                        latentShape: (frames: stage1Shape.frames, height: stage1Shape.height, width: stage1Shape.width),
+                        precomputedRoPE: extRoPE
+                    )
+                    let velocityPred = cropToOriginal(velocity: velocityPredExt, originalCount: appendOriginalCount)
+                    let videoVelocity = unpatchify(velocityPred, shape: stage1Shape).asType(.float32)
+                    videoLatent = stage1Scheduler.step(
+                        latent: videoLatent, velocity: videoVelocity,
+                        sigma: sigma, sigmaNext: sigmaNext
+                    )
+                    // No re-injection: guide tokens carry the keyframe info via attention.
+                    MLX.eval(videoLatent)
+                } else {
+                    // Video-only denoising (legacy path)
+                    let velocityPred = videoTransformer(
+                        latent: videoPatchified,
+                        context: videoTextEmbeddings.asType(.bfloat16),
+                        timesteps: videoTimestep,
+                        contextMask: nil,
+                        latentShape: (frames: stage1Shape.frames, height: stage1Shape.height, width: stage1Shape.width)
+                    )
 
-                let videoVelocity = unpatchify(velocityPred, shape: stage1Shape).asType(.float32)
+                    let videoVelocity = unpatchify(velocityPred, shape: stage1Shape).asType(.float32)
 
-                videoLatent = stage1Scheduler.step(
-                    latent: videoLatent, velocity: videoVelocity,
-                    sigma: sigma, sigmaNext: sigmaNext
-                )
-                if !halfResKeyframes.isEmpty {
-                    injectKeyframeLatents(into: &videoLatent, encoded: halfResKeyframes)
+                    videoLatent = stage1Scheduler.step(
+                        latent: videoLatent, velocity: videoVelocity,
+                        sigma: sigma, sigmaNext: sigmaNext
+                    )
+                    if !halfResKeyframes.isEmpty {
+                        injectKeyframeLatents(into: &videoLatent, encoded: halfResKeyframes)
+                    }
+                    MLX.eval(videoLatent)
                 }
-                MLX.eval(videoLatent)
             }
 
             if (step + 1) % 5 == 0 { Memory.clearCache() }
@@ -858,6 +949,40 @@ public actor LTXPipeline {
         }
 
         profiler.end("Denoising Stage 1")
+
+        // [PROTOTYPE] Early-exit hook for M1/M2/M3 measurement. Decodes the Stage 1
+        // half-res latent and returns it as the video result, bypassing upscale + Stage 2.
+        if stopAfterStage1 {
+            LTXDebug.log("[PROTO] LTX_STOP_AFTER_STAGE1=1 — decoding Stage 1 latent and exiting")
+            if let dumpPath = ProcessInfo.processInfo.environment["LTX_DUMP_FINAL_LATENT"] {
+                let l32 = videoLatent.asType(.float32)
+                MLX.eval(l32)
+                try? MLX.save(arrays: ["data": l32], url: URL(fileURLWithPath: dumpPath))
+                LTXDebug.log("[PROTO] dumped stage-1 latent to \(dumpPath): \(l32.shape)")
+            }
+            LTXMemoryManager.setPhase(.vaeDecode)
+            let stage1Decoded = decodeVideo(
+                latent: videoLatent, decoder: vaeDecoder, timestep: nil,
+                temporalTileSize: memoryOptimization.vaeTemporalTileSize,
+                temporalTileOverlap: memoryOptimization.vaeTemporalTileOverlap
+            )
+            MLX.eval(stage1Decoded)
+            let trimmed: MLXArray
+            if stage1Decoded.dim(0) > config.numFrames {
+                trimmed = stage1Decoded[0..<config.numFrames]
+            } else {
+                trimmed = stage1Decoded
+            }
+            let gen = Date().timeIntervalSince(generationStart)
+            return VideoGenerationResult(
+                frames: trimmed,
+                seed: config.seed ?? 0,
+                generationTime: gen,
+                audioWaveform: nil,
+                audioSampleRate: nil,
+                effectivePrompt: effectivePrompt
+            )
+        }
 
         // === UPSCALE VIDEO 2x (audio unchanged) ===
         onProgress?(GenerationProgress(
@@ -1663,7 +1788,7 @@ public actor LTXPipeline {
             MLX.eval(normalized)
             let slot = pixelFrameToLatentFrame(kf.pixelFrameIndex)
             LTXDebug.log("Keyframe \(kf.path) → pixel \(kf.pixelFrameIndex) → latent slot \(slot), shape=\(normalized.shape)")
-            encoded.append(EncodedKeyframe(latentIdx: slot, latent: normalized))
+            encoded.append(EncodedKeyframe(latentIdx: slot, latent: normalized, pixelFrameIndex: kf.pixelFrameIndex))
         }
         return encoded
     }

--- a/Sources/LTXVideo/Pipeline/LTXPipeline.swift
+++ b/Sources/LTXVideo/Pipeline/LTXPipeline.swift
@@ -1047,19 +1047,60 @@ public actor LTXPipeline {
         // I2V stage 2: encode keyframes at full resolution and inject
         var fullResKeyframes: [EncodedKeyframe] = []
         var stage2CondMask: MLXArray? = nil
+        let useAppendKeyframesS2 = useAppendKeyframes  // same env-var gate
         if isI2V {
             LTXDebug.log("Stage 2: encoding \(effectiveKeyframes.count) keyframe(s) at \(config.width)x\(config.height)")
             fullResKeyframes = try await encodeKeyframes(effectiveKeyframes, width: config.width, height: config.height)
             unloadVAEEncoder()
-            injectKeyframeLatents(into: &videoLatent, encoded: fullResKeyframes)
-
-            let slots = fullResKeyframes.map { $0.latentIdx }
-            let mask = buildKeyframeMask(latentIndices: slots, shape: stage2Shape)
-            MLX.eval(mask)
-            stage2CondMask = mask
+            if !useAppendKeyframesS2 {
+                injectKeyframeLatents(into: &videoLatent, encoded: fullResKeyframes)
+                let slots = fullResKeyframes.map { $0.latentIdx }
+                let mask = buildKeyframeMask(latentIndices: slots, shape: stage2Shape)
+                MLX.eval(mask)
+                stage2CondMask = mask
+            }
         }
         MLX.eval(videoLatent)
         if hasAudio, let ap = audioLatentPacked { MLX.eval(ap) }
+
+        // [PROTOTYPE] Stage 2 append: pre-build guides + extended positions + RoPE
+        var appendGuideTokensS2: MLXArray? = nil
+        var appendExtRoPES2: (cos: MLXArray, sin: MLXArray)? = nil
+        var appendOriginalCountS2: Int = 0
+        var appendGuideCountS2: Int = 0
+        if useAppendKeyframesS2, let videoTransformer = transformer, !fullResKeyframes.isEmpty {
+            let basePos = buildBaseVideoPositions(
+                batchSize: 1,
+                frames: stage2Shape.frames,
+                height: stage2Shape.height,
+                width: stage2Shape.width
+            )
+            let guides = fullResKeyframes.map { kf -> AppendedGuideTokens in
+                buildKeyframeGuideToken(
+                    encodedLatent: kf.latent,
+                    pixelFrameIndex: kf.pixelFrameIndex,
+                    fps: 24.0
+                )
+            }
+            let allGuideTokens = MLX.concatenated(guides.map { $0.tokens }, axis: 1)
+            let allGuidePositions = MLX.concatenated(guides.map { $0.positions }, axis: 2)
+            appendGuideTokensS2 = allGuideTokens
+            appendGuideCountS2 = allGuideTokens.dim(1)
+            appendOriginalCountS2 = stage2Shape.tokenCount
+            let extPositions = MLX.concatenated([basePos, allGuidePositions], axis: 2)
+            let pe = precomputeFreqsCis(
+                indicesGrid: extPositions,
+                dim: videoTransformer.config.innerDim,
+                theta: videoTransformer.config.ropeTheta,
+                maxPos: videoTransformer.config.maxPos,
+                numAttentionHeads: videoTransformer.config.numAttentionHeads,
+                ropeType: .split,
+                doublePrecision: true
+            )
+            MLX.eval(pe.cos, pe.sin)
+            appendExtRoPES2 = pe
+            LTXDebug.log("[PROTO Stage 2] extended sequence: \(appendOriginalCountS2) video + \(appendGuideCountS2) guide = \(appendOriginalCountS2 + appendGuideCountS2) tokens")
+        }
 
         // Dump re-noised latent
         if LTXDebug.isEnabled {
@@ -1127,22 +1168,46 @@ public actor LTXPipeline {
                 audioLatentPacked = updatedAudio
                 MLX.eval(videoLatent, updatedAudio)
             } else if let videoTransformer = transformer {
-                let velocityPred = videoTransformer(
-                    latent: videoPatchified,
-                    context: videoTextEmbeddings.asType(.bfloat16),
-                    timesteps: videoTimestep,
-                    contextMask: nil,
-                    latentShape: (frames: stage2Shape.frames, height: stage2Shape.height, width: stage2Shape.width)
-                )
+                if useAppendKeyframesS2,
+                   let guideTokens = appendGuideTokensS2,
+                   let extRoPE = appendExtRoPES2 {
+                    let extTokens = MLX.concatenated([videoPatchified, guideTokens], axis: 1)
+                    let extTimestep = buildExtendedTimestep(
+                        sigma: sigma,
+                        originalCount: appendOriginalCountS2,
+                        guideCount: appendGuideCountS2
+                    )
+                    let velocityPredExt = videoTransformer(
+                        latent: extTokens,
+                        context: videoTextEmbeddings.asType(.bfloat16),
+                        timesteps: extTimestep,
+                        contextMask: nil,
+                        latentShape: (frames: stage2Shape.frames, height: stage2Shape.height, width: stage2Shape.width),
+                        precomputedRoPE: extRoPE
+                    )
+                    let velocityPred = cropToOriginal(velocity: velocityPredExt, originalCount: appendOriginalCountS2)
+                    let videoVelocity = unpatchify(velocityPred, shape: stage2Shape).asType(.float32)
+                    let dt = sigmaNext - sigma
+                    videoLatent = videoLatent + MLXArray(dt) * videoVelocity
+                    MLX.eval(videoLatent)
+                } else {
+                    let velocityPred = videoTransformer(
+                        latent: videoPatchified,
+                        context: videoTextEmbeddings.asType(.bfloat16),
+                        timesteps: videoTimestep,
+                        contextMask: nil,
+                        latentShape: (frames: stage2Shape.frames, height: stage2Shape.height, width: stage2Shape.width)
+                    )
 
-                let videoVelocity = unpatchify(velocityPred, shape: stage2Shape).asType(.float32)
+                    let videoVelocity = unpatchify(velocityPred, shape: stage2Shape).asType(.float32)
 
-                let dt = sigmaNext - sigma
-                videoLatent = videoLatent + MLXArray(dt) * videoVelocity
-                if !fullResKeyframes.isEmpty {
-                    injectKeyframeLatents(into: &videoLatent, encoded: fullResKeyframes)
+                    let dt = sigmaNext - sigma
+                    videoLatent = videoLatent + MLXArray(dt) * videoVelocity
+                    if !fullResKeyframes.isEmpty {
+                        injectKeyframeLatents(into: &videoLatent, encoded: fullResKeyframes)
+                    }
+                    MLX.eval(videoLatent)
                 }
-                MLX.eval(videoLatent)
             }
 
             let stepDur2 = Date().timeIntervalSince(stepStart)

--- a/Sources/LTXVideo/Pipeline/LTXPipeline.swift
+++ b/Sources/LTXVideo/Pipeline/LTXPipeline.swift
@@ -752,74 +752,15 @@ public actor LTXPipeline {
 
         // Pre-build guide tokens, extended positions, and RoPE for the append path.
         // These are constant across denoising steps, so compute once.
-        var appendGuideTokens: MLXArray? = nil
-        var appendExtRoPE: (cos: MLXArray, sin: MLXArray)? = nil
-        var appendExtCrossVideoRoPE: (cos: MLXArray, sin: MLXArray)? = nil
-        var appendOriginalCount: Int = 0
-        var appendGuideCount: Int = 0
-        if useAppendKeyframes {
-            let basePos = createPositionGrid(
-                batchSize: 1,
-                frames: stage1Shape.frames,
-                height: stage1Shape.height,
-                width: stage1Shape.width
+        let stage1AppendCtx: AppendKeyframeContext? = useAppendKeyframes
+            ? prepareKeyframeAppend(
+                encoded: halfResKeyframes,
+                shape: stage1Shape,
+                hasAudio: hasAudio,
+                refConfig: transformer?.config ?? ltx2Transformer?.config ?? .default,
+                stageLabel: "Stage 1"
             )
-            let guides = halfResKeyframes.map { kf -> AppendedGuideTokens in
-                buildKeyframeGuideToken(
-                    encodedLatent: kf.latent,
-                    pixelFrameIndex: kf.pixelFrameIndex,
-                    fps: 24.0
-                )
-            }
-            let allGuideTokens = MLX.concatenated(guides.map { $0.tokens }, axis: 1)
-            let allGuidePositions = MLX.concatenated(guides.map { $0.positions }, axis: 2)
-            appendGuideTokens = allGuideTokens
-            appendGuideCount = allGuideTokens.dim(1)
-            appendOriginalCount = stage1Shape.tokenCount
-
-            let extPositions = MLX.concatenated([basePos, allGuidePositions], axis: 2)
-
-            // Pick the relevant transformer config (video-only or dual stream)
-            let refConfig: LTXTransformerConfig
-            if let videoTransformer = transformer {
-                refConfig = videoTransformer.config
-            } else if let dual = ltx2Transformer {
-                refConfig = dual.config
-            } else {
-                refConfig = .default
-            }
-
-            // Pre-compute RoPE for extended positions (used by both LTXTransformer and
-            // LTX2Transformer's video stream)
-            let pe = precomputeFreqsCis(
-                indicesGrid: extPositions,
-                dim: refConfig.innerDim,
-                theta: refConfig.ropeTheta,
-                maxPos: refConfig.maxPos,
-                numAttentionHeads: refConfig.numAttentionHeads,
-                ropeType: .split,
-                doublePrecision: true
-            )
-            MLX.eval(pe.cos, pe.sin)
-            appendExtRoPE = pe
-
-            // Cross-modal video RoPE (audio path only): temporal-only coords from extPositions
-            if hasAudio {
-                let temporalOnly = extPositions[0..., 0..<1, 0...]
-                let crossPE = precomputeFreqsCis(
-                    indicesGrid: temporalOnly,
-                    dim: refConfig.audioCrossAttentionDim,
-                    theta: refConfig.ropeTheta,
-                    maxPos: refConfig.audioMaxPos,
-                    numAttentionHeads: refConfig.audioNumAttentionHeads,
-                    ropeType: .split,
-                    doublePrecision: true
-                )
-                MLX.eval(crossPE.cos, crossPE.sin)
-                appendExtCrossVideoRoPE = crossPE
-            }
-            LTXDebug.log("[append] Stage 1 extended sequence: \(appendOriginalCount) video + \(appendGuideCount) guide tokens")
-        }
+            : nil
 
         // === STAGE 1: Denoise at half resolution ===
         let stage1NumSteps = stage1Sigmas.count - 1
@@ -850,15 +791,12 @@ public actor LTXPipeline {
                 let audioTimestep = MLXArray([sigma])
                 let audioPatchified = ap.asType(.bfloat16)
 
-                if useAppendKeyframes,
-                   let guideTokens = appendGuideTokens,
-                   let extRoPE = appendExtRoPE,
-                   let extCrossRoPE = appendExtCrossVideoRoPE {
-                    let extTokens = MLX.concatenated([videoPatchified, guideTokens], axis: 1)
+                if let ctx = stage1AppendCtx, let extCrossRoPE = ctx.extCrossVideoRoPE {
+                    let extTokens = MLX.concatenated([videoPatchified, ctx.guideTokens], axis: 1)
                     let extTimestep = buildExtendedTimestep(
                         sigma: sigma,
-                        originalCount: appendOriginalCount,
-                        guideCount: appendGuideCount
+                        originalCount: ctx.originalCount,
+                        guideCount: ctx.guideCount
                     )
                     let (videoVelPredExt, audioVelPred) = ltx2(
                         videoLatent: extTokens,
@@ -871,10 +809,10 @@ public actor LTXPipeline {
                         audioContextMask: nil,
                         videoLatentShape: (frames: stage1Shape.frames, height: stage1Shape.height, width: stage1Shape.width),
                         audioNumFrames: audioNumFrames,
-                        precomputedVideoRoPE: extRoPE,
+                        precomputedVideoRoPE: ctx.extRoPE,
                         precomputedCrossVideoRoPE: extCrossRoPE
                     )
-                    let videoVelPred = cropToOriginal(velocity: videoVelPredExt, originalCount: appendOriginalCount)
+                    let videoVelPred = cropToOriginal(velocity: videoVelPredExt, originalCount: ctx.originalCount)
                     let videoVelocity = unpatchify(videoVelPred, shape: stage1Shape).asType(.float32)
                     let audioVelocity = audioVelPred.asType(.float32)
                     videoLatent = stage1Scheduler.step(
@@ -910,15 +848,13 @@ public actor LTXPipeline {
                     MLX.eval(videoLatent, updatedAudio)
                 }
             } else if let videoTransformer = transformer {
-                if useAppendKeyframes,
-                   let guideTokens = appendGuideTokens,
-                   let extRoPE = appendExtRoPE {
+                if let ctx = stage1AppendCtx {
                     // Append guide tokens for keyframe conditioning (issue #21 fix).
-                    let extTokens = MLX.concatenated([videoPatchified, guideTokens], axis: 1)
+                    let extTokens = MLX.concatenated([videoPatchified, ctx.guideTokens], axis: 1)
                     let extTimestep = buildExtendedTimestep(
                         sigma: sigma,
-                        originalCount: appendOriginalCount,
-                        guideCount: appendGuideCount
+                        originalCount: ctx.originalCount,
+                        guideCount: ctx.guideCount
                     )
                     let velocityPredExt = videoTransformer(
                         latent: extTokens,
@@ -926,9 +862,9 @@ public actor LTXPipeline {
                         timesteps: extTimestep,
                         contextMask: nil,
                         latentShape: (frames: stage1Shape.frames, height: stage1Shape.height, width: stage1Shape.width),
-                        precomputedRoPE: extRoPE
+                        precomputedRoPE: ctx.extRoPE
                     )
-                    let velocityPred = cropToOriginal(velocity: velocityPredExt, originalCount: appendOriginalCount)
+                    let velocityPred = cropToOriginal(velocity: velocityPredExt, originalCount: ctx.originalCount)
                     let videoVelocity = unpatchify(velocityPred, shape: stage1Shape).asType(.float32)
                     videoLatent = stage1Scheduler.step(
                         latent: videoLatent, velocity: videoVelocity,
@@ -1047,70 +983,16 @@ public actor LTXPipeline {
         MLX.eval(videoLatent)
         if hasAudio, let ap = audioLatentPacked { MLX.eval(ap) }
 
-        // [append] Stage 2 append: pre-build guides + extended positions + RoPE
-        var appendGuideTokensS2: MLXArray? = nil
-        var appendExtRoPES2: (cos: MLXArray, sin: MLXArray)? = nil
-        var appendExtCrossVideoRoPES2: (cos: MLXArray, sin: MLXArray)? = nil
-        var appendOriginalCountS2: Int = 0
-        var appendGuideCountS2: Int = 0
-        if useAppendKeyframesS2, !fullResKeyframes.isEmpty {
-            let basePos = createPositionGrid(
-                batchSize: 1,
-                frames: stage2Shape.frames,
-                height: stage2Shape.height,
-                width: stage2Shape.width
+        // Pre-build guide tokens, extended positions, and RoPE for the Stage 2 append path.
+        let stage2AppendCtx: AppendKeyframeContext? = useAppendKeyframesS2
+            ? prepareKeyframeAppend(
+                encoded: fullResKeyframes,
+                shape: stage2Shape,
+                hasAudio: hasAudio,
+                refConfig: transformer?.config ?? ltx2Transformer?.config ?? .default,
+                stageLabel: "Stage 2"
             )
-            let guides = fullResKeyframes.map { kf -> AppendedGuideTokens in
-                buildKeyframeGuideToken(
-                    encodedLatent: kf.latent,
-                    pixelFrameIndex: kf.pixelFrameIndex,
-                    fps: 24.0
-                )
-            }
-            let allGuideTokens = MLX.concatenated(guides.map { $0.tokens }, axis: 1)
-            let allGuidePositions = MLX.concatenated(guides.map { $0.positions }, axis: 2)
-            appendGuideTokensS2 = allGuideTokens
-            appendGuideCountS2 = allGuideTokens.dim(1)
-            appendOriginalCountS2 = stage2Shape.tokenCount
-            let extPositions = MLX.concatenated([basePos, allGuidePositions], axis: 2)
-
-            let refConfig: LTXTransformerConfig
-            if let videoTransformer = transformer {
-                refConfig = videoTransformer.config
-            } else if let dual = ltx2Transformer {
-                refConfig = dual.config
-            } else {
-                refConfig = .default
-            }
-
-            let pe = precomputeFreqsCis(
-                indicesGrid: extPositions,
-                dim: refConfig.innerDim,
-                theta: refConfig.ropeTheta,
-                maxPos: refConfig.maxPos,
-                numAttentionHeads: refConfig.numAttentionHeads,
-                ropeType: .split,
-                doublePrecision: true
-            )
-            MLX.eval(pe.cos, pe.sin)
-            appendExtRoPES2 = pe
-
-            if hasAudio {
-                let temporalOnly = extPositions[0..., 0..<1, 0...]
-                let crossPE = precomputeFreqsCis(
-                    indicesGrid: temporalOnly,
-                    dim: refConfig.audioCrossAttentionDim,
-                    theta: refConfig.ropeTheta,
-                    maxPos: refConfig.audioMaxPos,
-                    numAttentionHeads: refConfig.audioNumAttentionHeads,
-                    ropeType: .split,
-                    doublePrecision: true
-                )
-                MLX.eval(crossPE.cos, crossPE.sin)
-                appendExtCrossVideoRoPES2 = crossPE
-            }
-            LTXDebug.log("[append] Stage 2 extended sequence: \(appendOriginalCountS2) video + \(appendGuideCountS2) guide tokens")
-        }
+            : nil
 
         // Dump re-noised latent
         if LTXDebug.isEnabled {
@@ -1140,15 +1022,12 @@ public actor LTXPipeline {
                 let audioTimestep = MLXArray([sigma])
                 let audioPatchified = ap.asType(.bfloat16)
 
-                if useAppendKeyframesS2,
-                   let guideTokens = appendGuideTokensS2,
-                   let extRoPE = appendExtRoPES2,
-                   let extCrossRoPE = appendExtCrossVideoRoPES2 {
-                    let extTokens = MLX.concatenated([videoPatchified, guideTokens], axis: 1)
+                if let ctx = stage2AppendCtx, let extCrossRoPE = ctx.extCrossVideoRoPE {
+                    let extTokens = MLX.concatenated([videoPatchified, ctx.guideTokens], axis: 1)
                     let extTimestep = buildExtendedTimestep(
                         sigma: sigma,
-                        originalCount: appendOriginalCountS2,
-                        guideCount: appendGuideCountS2
+                        originalCount: ctx.originalCount,
+                        guideCount: ctx.guideCount
                     )
                     let (videoVelPredExt, audioVelPred) = ltx2(
                         videoLatent: extTokens,
@@ -1161,10 +1040,10 @@ public actor LTXPipeline {
                         audioContextMask: nil,
                         videoLatentShape: (frames: stage2Shape.frames, height: stage2Shape.height, width: stage2Shape.width),
                         audioNumFrames: audioNumFrames,
-                        precomputedVideoRoPE: extRoPE,
+                        precomputedVideoRoPE: ctx.extRoPE,
                         precomputedCrossVideoRoPE: extCrossRoPE
                     )
-                    let videoVelPred = cropToOriginal(velocity: videoVelPredExt, originalCount: appendOriginalCountS2)
+                    let videoVelPred = cropToOriginal(velocity: videoVelPredExt, originalCount: ctx.originalCount)
                     let videoVelocity = unpatchify(videoVelPred, shape: stage2Shape).asType(.float32)
                     let audioVelocity = audioVelPred.asType(.float32)
                     let dt = sigmaNext - sigma
@@ -1196,14 +1075,12 @@ public actor LTXPipeline {
                     MLX.eval(videoLatent, updatedAudio)
                 }
             } else if let videoTransformer = transformer {
-                if useAppendKeyframesS2,
-                   let guideTokens = appendGuideTokensS2,
-                   let extRoPE = appendExtRoPES2 {
-                    let extTokens = MLX.concatenated([videoPatchified, guideTokens], axis: 1)
+                if let ctx = stage2AppendCtx {
+                    let extTokens = MLX.concatenated([videoPatchified, ctx.guideTokens], axis: 1)
                     let extTimestep = buildExtendedTimestep(
                         sigma: sigma,
-                        originalCount: appendOriginalCountS2,
-                        guideCount: appendGuideCountS2
+                        originalCount: ctx.originalCount,
+                        guideCount: ctx.guideCount
                     )
                     let velocityPredExt = videoTransformer(
                         latent: extTokens,
@@ -1211,9 +1088,9 @@ public actor LTXPipeline {
                         timesteps: extTimestep,
                         contextMask: nil,
                         latentShape: (frames: stage2Shape.frames, height: stage2Shape.height, width: stage2Shape.width),
-                        precomputedRoPE: extRoPE
+                        precomputedRoPE: ctx.extRoPE
                     )
-                    let velocityPred = cropToOriginal(velocity: velocityPredExt, originalCount: appendOriginalCountS2)
+                    let velocityPred = cropToOriginal(velocity: velocityPredExt, originalCount: ctx.originalCount)
                     let videoVelocity = unpatchify(velocityPred, shape: stage2Shape).asType(.float32)
                     let dt = sigmaNext - sigma
                     videoLatent = videoLatent + MLXArray(dt) * videoVelocity

--- a/Tests/LTXVideoTests/AppendedGuideTokensTests.swift
+++ b/Tests/LTXVideoTests/AppendedGuideTokensTests.swift
@@ -1,0 +1,134 @@
+//
+//  AppendedGuideTokensTests.swift
+//  ltx-video-swift-mlx
+//
+//  Tests for the keyframe-as-appended-guide-tokens primitive that backs the
+//  issue #21 fix: keyframe latents are concatenated to the video token sequence
+//  with shifted RoPE positions and σ=0 timesteps, then cropped after the
+//  transformer forward pass.
+//
+
+import Testing
+import Foundation
+@preconcurrency import MLX
+@testable import LTXVideo
+
+@Suite("AppendedGuideTokens — primitive helpers")
+struct AppendedGuideTokensHelperTests {
+
+    // MARK: - buildExtendedTimestep
+
+    @Test func testExtendedTimestepIsSigmaThenZero() {
+        let ts = buildExtendedTimestep(sigma: 0.5, originalCount: 6, guideCount: 3)
+        #expect(ts.shape == [1, 9])
+        let arr = ts.asArray(Float.self)
+        for i in 0..<6 { #expect(arr[i] == 0.5, "original token \(i) should hold sigma") }
+        for i in 6..<9 { #expect(arr[i] == 0.0, "guide token \(i) should hold σ=0") }
+    }
+
+    @Test func testExtendedTimestepZeroGuides() {
+        let ts = buildExtendedTimestep(sigma: 1.0, originalCount: 4, guideCount: 0)
+        #expect(ts.shape == [1, 4])
+        let arr = ts.asArray(Float.self)
+        #expect(arr.allSatisfy { $0 == 1.0 })
+    }
+
+    @Test func testExtendedTimestepZeroSigma() {
+        // Even when sigma=0 (last denoise step), the timestep tensor should be all zeros —
+        // the structure is preserved.
+        let ts = buildExtendedTimestep(sigma: 0.0, originalCount: 4, guideCount: 2)
+        #expect(ts.shape == [1, 6])
+        let arr = ts.asArray(Float.self)
+        #expect(arr.allSatisfy { $0 == 0.0 })
+    }
+
+    // MARK: - cropToOriginal
+
+    @Test func testCropToOriginalKeepsFirstNTokens() {
+        // Build a velocity (1, 5, 3) where each token's first channel = its index
+        let values: [Float] = [
+            10, 0, 0, 11, 0, 0, 12, 0, 0, 13, 0, 0, 14, 0, 0
+        ]
+        let v = MLXArray(values, [1, 5, 3])
+        let cropped = cropToOriginal(velocity: v, originalCount: 3)
+        #expect(cropped.shape == [1, 3, 3])
+        let arr = cropped.asArray(Float.self)
+        #expect(arr[0] == 10)
+        #expect(arr[3] == 11)
+        #expect(arr[6] == 12)
+    }
+
+    @Test func testCropToOriginalNoCropWhenCountEqualsTotal() {
+        let v = MLXArray.zeros([1, 8, 4])
+        let cropped = cropToOriginal(velocity: v, originalCount: 8)
+        #expect(cropped.shape == [1, 8, 4])
+    }
+}
+
+@Suite("buildKeyframeGuideToken — keyframe → guide token + positions")
+struct BuildKeyframeGuideTokenTests {
+
+    private func makeFakeLatent(h: Int, w: Int) -> MLXArray {
+        // shape (1, 128, 1, h, w) — match the VAE-encoded keyframe layout
+        return MLXArray.zeros([1, 128, 1, h, w])
+    }
+
+    @Test func testOutputShapes() {
+        // 8×8 latent (e.g. 256×256 pixel at 32× spatial scale)
+        let kf = makeFakeLatent(h: 8, w: 8)
+        let guide = buildKeyframeGuideToken(encodedLatent: kf, pixelFrameIndex: 0)
+        // 8*8 = 64 tokens, 128 channels (VAE channels) after patchify
+        #expect(guide.tokens.shape == [1, 64, 128])
+        #expect(guide.positions.shape == [1, 3, 64])
+    }
+
+    @Test func testTemporalPositionMatchesPixelFrame() {
+        // For num_pixel_frames=1, time = (pixelFrameIndex + 0.5) / fps
+        let kf = makeFakeLatent(h: 4, w: 4)
+        let fps: Float = 24.0
+        for pixelFrame in [0, 8, 16, 32, 60, 120] {
+            let guide = buildKeyframeGuideToken(encodedLatent: kf, pixelFrameIndex: pixelFrame, fps: fps)
+            let temporal = guide.positions[0, 0, 0...].asArray(Float.self)
+            let expected = (Float(pixelFrame) + 0.5) / fps
+            for t in temporal {
+                #expect(abs(t - expected) < 1e-4, "pixel \(pixelFrame): got \(t), expected \(expected)")
+            }
+        }
+    }
+
+    @Test func testSpatialPositionsAreMiddleOfPixelRange() {
+        // Spatial coord for latent index i = i*scale + scale/2 (no fps division)
+        let kf = makeFakeLatent(h: 2, w: 2)
+        let guide = buildKeyframeGuideToken(encodedLatent: kf, pixelFrameIndex: 0, spatialScale: 32)
+        let hCoords = guide.positions[0, 1, 0...].asArray(Float.self)
+        let wCoords = guide.positions[0, 2, 0...].asArray(Float.self)
+        // Token order: (h=0,w=0), (h=0,w=1), (h=1,w=0), (h=1,w=1)
+        // h centers: 16, 48 ; w centers: 16, 48
+        #expect(hCoords[0] == 16)
+        #expect(hCoords[1] == 16)
+        #expect(hCoords[2] == 48)
+        #expect(hCoords[3] == 48)
+        #expect(wCoords[0] == 16)
+        #expect(wCoords[1] == 48)
+        #expect(wCoords[2] == 16)
+        #expect(wCoords[3] == 48)
+    }
+
+    @Test func testFrameZeroMatchesBaseSequenceSlot0Position() {
+        // The canonical check: a keyframe at pixel 0 should have the SAME temporal
+        // position as the base video sequence's slot 0 (causal_fix + 1-frame range).
+        // base slot 0 (causalFix=true): start=0, end=1, middle = 0.5/fps
+        // guide @ pixel 0: (0 + 0.5)/fps = 0.5/fps  ✓
+        let kf = makeFakeLatent(h: 1, w: 1)
+        let guide = buildKeyframeGuideToken(encodedLatent: kf, pixelFrameIndex: 0, fps: 24.0)
+        let t = guide.positions[0, 0, 0].item(Float.self)
+        #expect(abs(t - 0.5 / 24.0) < 1e-5)
+    }
+
+    @Test func testTokensAreFlattenedPatches() {
+        // Patchify (1, C=128, 1, H, W) → (1, H*W, C)
+        let kf = makeFakeLatent(h: 3, w: 5)
+        let guide = buildKeyframeGuideToken(encodedLatent: kf, pixelFrameIndex: 0)
+        #expect(guide.tokens.shape == [1, 15, 128])
+    }
+}

--- a/Tests/LTXVideoTests/KeyframeInterpolationTests.swift
+++ b/Tests/LTXVideoTests/KeyframeInterpolationTests.swift
@@ -2,7 +2,9 @@
 //  KeyframeInterpolationTests.swift
 //  ltx-video-swift-mlx
 //
-//  Tests for multi-keyframe interpolation helpers.
+//  Tests for multi-keyframe interpolation public API (KeyframeInput, validation,
+//  pixel→latent index mapping). The append-based conditioning math is covered in
+//  AppendedGuideTokensTests.
 //
 
 import Testing
@@ -67,11 +69,24 @@ struct ValidateKeyframesTests {
     @Test func testValidMultiKeyframe() throws {
         let path = try makeTempImage()
         defer { try? FileManager.default.removeItem(atPath: path) }
-        // Slots 0 and 15 — different latent groups, no collision
         try validateKeyframes([
             KeyframeInput(path: path, pixelFrameIndex: 0),
+            KeyframeInput(path: path, pixelFrameIndex: 60),
             KeyframeInput(path: path, pixelFrameIndex: 120)
         ], numFrames: 121)
+    }
+
+    /// With the append-based conditioning, two keyframes within the same 8-frame
+    /// latent stride group are allowed — each appended guide token has its own
+    /// RoPE temporal position derived from `pixelFrameIndex`, not the latent slot.
+    @Test func testSameLatentStrideGroupIsAllowed() throws {
+        let path = try makeTempImage()
+        defer { try? FileManager.default.removeItem(atPath: path) }
+        // Pixel 1 and pixel 8 both map to latent slot 1 — now permitted.
+        try validateKeyframes([
+            KeyframeInput(path: path, pixelFrameIndex: 1),
+            KeyframeInput(path: path, pixelFrameIndex: 8)
+        ], numFrames: 17)
     }
 
     @Test func testMissingFileFails() {
@@ -109,8 +124,7 @@ struct ValidateKeyframesTests {
     }
 
     @Test func testStrengthBelowOneFails() throws {
-        // Soft conditioning is not yet implemented — values in (0, 1) must be rejected
-        // explicitly so users don't silently get hard injection when expecting blending.
+        // Soft conditioning is not yet implemented — values in (0, 1) must be rejected.
         let path = try makeTempImage()
         defer { try? FileManager.default.removeItem(atPath: path) }
         #expect(throws: LTXError.self) {
@@ -127,70 +141,6 @@ struct ValidateKeyframesTests {
                 KeyframeInput(path: path, pixelFrameIndex: 8)
             ], numFrames: 17)
         }
-    }
-
-    @Test func testCollidingLatentSlotsFails() throws {
-        // Pixel 1 and pixel 8 both map to latent slot 1 — must be rejected.
-        let path = try makeTempImage()
-        defer { try? FileManager.default.removeItem(atPath: path) }
-        #expect(throws: LTXError.self) {
-            try validateKeyframes([
-                KeyframeInput(path: path, pixelFrameIndex: 1),
-                KeyframeInput(path: path, pixelFrameIndex: 8)
-            ], numFrames: 17)
-        }
-    }
-}
-
-// MARK: - buildKeyframeMask
-
-@Suite("buildKeyframeMask")
-struct BuildKeyframeMaskTests {
-    /// Latent shape: 4 frames × 3 height × 2 width = 24 tokens (12 tokens per latent frame? no — 6 per frame)
-    /// Tokens per frame = height × width = 3 × 2 = 6. Total = 4 × 6 = 24.
-    private let shape = VideoLatentShape(batch: 1, channels: 128, frames: 4, height: 3, width: 2)
-
-    @Test func testEmptyMaskIsAllZeros() {
-        let mask = buildKeyframeMask(latentIndices: [], shape: shape)
-        #expect(mask.shape == [1, 24])
-        let arr = mask.asArray(Float.self)
-        #expect(arr.allSatisfy { $0 == 0.0 })
-    }
-
-    @Test func testSingleKeyframeAtFrameZero() {
-        let mask = buildKeyframeMask(latentIndices: [0], shape: shape)
-        let arr = mask.asArray(Float.self)
-        #expect(arr.count == 24)
-        // Tokens 0..5 should be 1.0, the rest 0.0
-        for t in 0..<6 { #expect(arr[t] == 1.0) }
-        for t in 6..<24 { #expect(arr[t] == 0.0) }
-    }
-
-    @Test func testKeyframeAtMiddleSlot() {
-        let mask = buildKeyframeMask(latentIndices: [2], shape: shape)
-        let arr = mask.asArray(Float.self)
-        // Tokens 12..17 (slot 2) should be 1.0
-        for t in 0..<12 { #expect(arr[t] == 0.0) }
-        for t in 12..<18 { #expect(arr[t] == 1.0) }
-        for t in 18..<24 { #expect(arr[t] == 0.0) }
-    }
-
-    @Test func testMultipleKeyframes() {
-        let mask = buildKeyframeMask(latentIndices: [0, 3], shape: shape)
-        let arr = mask.asArray(Float.self)
-        // Slot 0: tokens 0..5 → 1.0
-        // Slot 3: tokens 18..23 → 1.0
-        // Slots 1,2: tokens 6..17 → 0.0
-        for t in 0..<6 { #expect(arr[t] == 1.0) }
-        for t in 6..<18 { #expect(arr[t] == 0.0) }
-        for t in 18..<24 { #expect(arr[t] == 1.0) }
-    }
-
-    @Test func testOutOfRangeIndexIsIgnored() {
-        // Index 99 is way outside the 4-frame shape — should be silently dropped.
-        let mask = buildKeyframeMask(latentIndices: [99], shape: shape)
-        let arr = mask.asArray(Float.self)
-        #expect(arr.allSatisfy { $0 == 0.0 })
     }
 }
 

--- a/docs/examples/keyframe-interpolation/README.md
+++ b/docs/examples/keyframe-interpolation/README.md
@@ -6,20 +6,23 @@ frame conditioning, in any combination.
 
 ## How It Works
 
-Each keyframe is VAE-encoded into a single latent slot, then placed at the latent
-frame matching its pixel index (latent stride = 8, so pixel 0 → slot 0, pixels
-1–8 → slot 1, …, pixels 113–120 → slot 15, etc.). At every denoising step:
+Each keyframe is VAE-encoded then **appended** as extra tokens to the video
+sequence inside the transformer, with RoPE positions set to
+`(pixelFrameIndex + 0.5) / fps` (the pixel-space midpoint of a 1-frame range
+at the target). Their timestep is hardcoded to `σ = 0` so the model treats
+them as clean references; the rest of the video tokens are denoised normally
+at the schedule's current σ.
 
-1. The per-token timestep mask sets `σ = 0` at every keyframe slot, `σ = sigma`
-   elsewhere — so the transformer sees keyframe slots as already-clean references
-   while denoising the rest.
-2. The full latent is stepped by the scheduler.
-3. Keyframe slots are re-injected with the clean encoded latent, overwriting
-   the wrong update applied by the scalar-sigma scheduler at those positions.
+After each forward pass, the predicted velocity for the appended tokens is
+**cropped** away — only the original video tokens go through the scheduler
+step. The appended guide tokens are re-supplied at every step, never drift,
+and never enter the final latent.
 
-This is mathematically equivalent to the previous frame-0-only I2V path when a
-single keyframe is placed at pixel 0, so the existing `--image` flag is preserved
-as syntactic sugar.
+This matches Lightricks `VideoConditionByKeyframeIndex`. It replaces the
+previous "overwrite the latent slot" approach which produced grainy artifacts
+at non-zero keyframe positions (issue #21): a single-frame VAE encoding placed
+at a slot representing 8 pixel frames is structurally incompatible with what
+the decoder expects.
 
 ## CLI
 
@@ -36,24 +39,30 @@ for `--keyframe PATH:0` (the two flags are mutually exclusive).
 ### Constraints
 
 - Pixel `FRAME_IDX` must be in `[0, numFrames - 1]`.
-- Two keyframes within the same 8-pixel-frame group share the same latent slot
-  and are rejected (e.g. `pixel 1` and `pixel 8` both map to latent slot 1).
-- `STRENGTH` must be exactly `1.0` (hard injection). Values `!= 1.0` are
-  rejected by the validator until soft conditioning is wired through in a
-  future PR.
+- `STRENGTH` must be exactly `1.0`. Values `!= 1.0` are rejected until soft
+  conditioning is wired through in a future PR.
 - Multi-keyframe combined with `--video` (retake) is not supported.
 
-### Behavioral note vs. legacy `--image`
+Multiple keyframes within the same 8-pixel-frame latent stride group **are**
+allowed since each appended guide token carries its own RoPE temporal position
+independent of the underlying latent slot.
 
-When `imageCondNoiseScale == 0` (the default), the new keyframe path is
-mathematically equivalent to the previous frame-0-only frame-skip Euler step.
+### Performance
 
-When `imageCondNoiseScale > 0`, there is one subtle divergence: the new code
-unconditionally re-injects the **clean** keyframe latent at the end of every
-denoising step, whereas the previous code left the noised pre-step injection
-in place at the end of stage 1. The new behavior produces a cleaner final
-keyframe slot — arguably more correct, but a possible visible difference for
-users who relied on the old behavior with non-zero noise scale.
+The append path adds ~50% to generation time at small frame counts (more
+attention tokens, no RoPE cache reuse). The cost is roughly constant in
+keyframe count for a fixed video size — each keyframe contributes
+`latentH × latentW` extra tokens.
+
+### Issue #21 — noise reduction at non-zero keyframes
+
+Measured on 33-frame 768×512 with 3 keyframes (pixels 0/16/32), seed 42:
+
+| Metric | Legacy hard-inject | This append path | Improvement |
+|---|---|---|---|
+| hf_energy at keyframes | 0.149 | 0.126 | **−15.5%** |
+| hf_energy elsewhere | 0.148 | 0.130 | **−12.2%** |
+| L1 vs ref at keyframes | 0.059 | 0.059 | equivalent |
 
 ---
 


### PR DESCRIPTION
Closes #21.

## Summary

Replaces the legacy hard-injection keyframe path (overwrite a latent slot with a single-frame VAE encoding) with **appended guide tokens at shifted RoPE positions**, matching Lightricks `VideoConditionByKeyframeIndex`. Applies to the full two-stage pipeline (video-only and audio paths, Stage 1 and Stage 2).

Each keyframe is VAE-encoded, patchified, appended to the video token sequence with RoPE temporal coord `(pixelFrameIndex + 0.5) / fps` and timestep σ=0. The transformer "sees" the keyframe via attention; the predicted velocity for the appended tokens is cropped before the scheduler step. Appended tokens never enter the final latent.

## Why

The legacy code only worked at slot 0 (the standalone "+1" frame). At slot N≥1, the slot represents 8 pixel frames of motion, so injecting a still encoding produces grainy artifacts at non-zero keyframes — the bug reported in #21 by @sxw917.

## End-to-end validation — exact #21 reproducer

`ltx-video generate "..." --keyframe img.png:0 --keyframe img.png:60 --keyframe img.png:120 -w 768 -h 512 -f 121 --seed 42`

### Pinning at keyframes (L1 vs reference, lower = better)

| Frame | LEGACY | APPEND |
|---|---|---|
| 0 | 0.058 | 0.058 |
| **60** | **0.073** ⚠️ | **0.058** ✅ |
| **120** | **0.081** ⚠️ | **0.058** ✅ |

Legacy fails to pin frames 60 and 120 — they drift 25–40% from the reference. Append pins all three keyframes equally.

### High-frequency energy at the worst keyframe (lower = less noise)

| | LEGACY | APPEND |
|---|---|---|
| `hf_energy` at frame 120 | **0.169** ⚠️ | **0.107** ✅ |
| Reduction | | **−37%** |

### Aggregate over the 121-frame run

| Region | LEGACY hf | APPEND hf | Δ |
|---|---|---|---|
| At keyframes (0/60/120) | 0.1315 | 0.1165 | **−11.4%** |
| Near keyframes (±5 frames) | 0.1107 | 0.1134 | +2.4% |
| Mid-zone (10-50, 70-110) | 0.0886 | 0.0985 | +11.1% (legacy's drift artifact) |

The "mid-zone uplift" in append is real — legacy actually drifts toward an over-smoothed (low hf_energy = blurry) image around frame 60-100 because the keyframe at 60 fails to anchor; append maintains consistent quality which means slightly higher mid-zone hf, but it tracks the reference correctly.

### Refactor validation (separate from bug fix, same PR)

Same 17-frame 3-keyframe scenario before and after the `prepareKeyframeAppend` + `runDenoiseStep` refactors:

```
max abs frame diff = 0.0000  (bit-perfect across 7 sampled frames)
```

The two helpers (`prepareKeyframeAppend` and `runDenoiseStep`) are pure structural transformations — zero numerical impact.

## Implementation

- **`Sources/LTXVideo/Pipeline/AppendedGuideTokens.swift`** *(new, ~200 lines)*:
  - `AppendedGuideTokens` struct: keyframe tokens + RoPE positions
  - `AppendKeyframeContext` struct: full per-stage append state (guide tokens + extended video RoPE + cross-modal video RoPE + counts)
  - `buildKeyframeGuideToken`: VAE-encoded keyframe → patchified tokens + RoPE positions with single-frame temporal narrowing
  - `prepareKeyframeAppend`: builds the full per-stage context (called once per stage, constant across denoising steps)
  - `buildExtendedTimestep` / `cropToOriginal`: per-step token utilities

- **`Sources/LTXVideo/Models/Transformer/LTXTransformer.swift`** + **`LTX2Transformer.swift`**: optional `precomputedRoPE` / `precomputedVideoRoPE` / `precomputedCrossVideoRoPE` params bypass the cached RoPE derivation when guide tokens extend the sequence beyond `latentShape`.

- **`Sources/LTXVideo/Pipeline/LTXPipeline.swift`**: each denoise step in each stage collapses from ~110 lines (4 if/else branches) to ~23 lines: one call to `runDenoiseStep` (a private actor method that handles patchify + optional concat + transformer call + crop + unpatchify), then the stage-specific scheduler step.

- **`Sources/LTXVideo/Pipeline/KeyframeInterpolation.swift`**: drop `injectKeyframeLatents` and `buildKeyframeMask` (dead). `validateKeyframes` no longer rejects multiple keyframes within the same latent stride group — each gets its own RoPE position.

- **`Sources/LTXVideo/Configuration/LTXConfig.swift`**: `imageCondNoiseScale` deprecated as no-op; backed by private storage so internal init writes don't trip the deprecation warning. Kept for SPM source-compat.

- **`Tests/LTXVideoTests/AppendedGuideTokensTests.swift`** *(new, 11 cases)*: extended timestep layout, crop shape/content, build keyframe positions (frame-0 ↔ base sequence parity, non-zero pixel positions, spatial midpoints, output shape).

- **`Tests/LTXVideoTests/KeyframeInterpolationTests.swift`**: drop obsolete `buildKeyframeMask` suite; rename + invert the latent-slot-collision test to `testSameLatentStrideGroupIsAllowed`.

## Cost

Append adds attention tokens proportional to `K × latentH × latentW`. Concrete measurements:

- 17 frames @ 768×512, 3 keyframes: 119s legacy → 171s append (+44%)
- 121 frames @ 768×512, 3 keyframes: 461s legacy → 589s append (+28%)

The relative cost goes down as the base video grows (the keyframe contribution is roughly constant, the base sequence dominates).

## What's not in scope

- Soft strength `< 1.0` — still rejected by validation; trivial to plug in later (`σ * (1 - strength)` on guides instead of `0`).
- Audio reference latent for lipdub — separate follow-up, will reuse `AppendedGuideTokens` on the audio side with negative RoPE positions.

## Test plan

- [x] `xcodebuild test` — 174/174 pass (includes 11 new keyframe tests)
- [x] `--image` regression at 768×512 9-frames — L1 vs ref unchanged (0.056)
- [x] Multi-keyframe 17 frames — pinning OK, no noise
- [x] **Issue #21 exact reproducer** (121 frames, keyframes 0/60/120, seed 42) — bug is **eliminated**: legacy fails to pin frames 60/120 with hf_energy spike to 0.169 at frame 120; append pins all three at L1=0.058 with hf_energy 0.107 at frame 120
- [x] Sub-latent: keyframes at pixel 6 + pixel 8 (both → latent slot 1) — works, was previously rejected
- [x] Refactor validation: bit-perfect output before/after `runDenoiseStep` extraction (max abs frame diff = 0.0000)

🤖 Generated with [Claude Code](https://claude.com/claude-code)