### PR TITLE
Add LoRA support to retake command and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,12 @@ ltx-video retake "Replace the red ball with a fireball with blazing flames and s
     --video source.mp4 \
     --start-time 5.0 --end-time 7.0 -w 512 -h 512 -f 233
 
+# Retake with LoRA (same flags as generate)
+ltx-video retake "A cinematic arc shot around a vintage red car" \
+    --video source.mp4 \
+    --lora /path/to/lora.safetensors --lora-scale 0.8 \
+    -w 768 -h 512 -f 121
+
 # Use distilled mode for faster inference (default: dev model with CFG)
 ltx-video retake "The vase explodes into colorful smoke" \
     --video source.mp4 --distilled \

--- a/Sources/LTXVideoCLI/LTXVideoCLI.swift
+++ b/Sources/LTXVideoCLI/LTXVideoCLI.swift
@@ -386,6 +386,12 @@ struct Retake: AsyncParsableCommand {
     @Option(name: .long, help: "End time in seconds for partial retake (default: retake all frames)")
     var endTime: Float?
 
+    @Option(name: .long, help: "Path to LoRA .safetensors file to apply during retake")
+    var lora: String?
+
+    @Option(name: .long, help: "LoRA scale factor (default: 1.0)")
+    var loraScale: Float = 1.0
+
     @Option(name: .shortAndLong, help: "Output file path (default: retake.mp4)")
     var output: String = "retake.mp4"
 
@@ -485,6 +491,7 @@ struct Retake: AsyncParsableCommand {
             print("Seed: \(seed)")
         }
         if enhancePrompt { print("Prompt enhancement: enabled") }
+        if let loraPath = lora { print("LoRA: \(loraPath) (scale: \(loraScale))") }
         if transformerQuant != "bf16" { print("Transformer quantization: \(transformerQuant)") }
         print()
 
@@ -497,6 +504,17 @@ struct Retake: AsyncParsableCommand {
         }
         guard FileManager.default.fileExists(atPath: video) else {
             throw ValidationError("Source video not found: \(video)")
+        }
+        if let loraPath = lora {
+            guard FileManager.default.fileExists(atPath: loraPath) else {
+                throw ValidationError("LoRA file not found: \(loraPath)")
+            }
+        }
+        guard loraScale.isFinite else {
+            throw ValidationError("LoRA scale must be finite. Got \(loraScale)")
+        }
+        guard loraScale >= 0 else {
+            throw ValidationError("LoRA scale must be >= 0. Got \(loraScale)")
         }
         // Parse quantization
         let quantConfig: LTXQuantizationConfig
@@ -543,6 +561,14 @@ struct Retake: AsyncParsableCommand {
                 print("  \(progress.message) (\(Int(progress.progress * 100))%)")
             }
             print("Audio models loaded")
+        }
+
+        // Fuse LoRA if specified (after loading final transformer variant)
+        if let loraPath = lora {
+            print("Fusing LoRA weights...")
+            fflush(stdout)
+            let fusedCount = try await pipeline.fuseLoRA(from: loraPath, scale: loraScale)
+            print("LoRA fused (\(fusedCount) weight updates)")
         }
 
         // Build config

--- a/docs/examples/retake/README.md
+++ b/docs/examples/retake/README.md
@@ -111,6 +111,32 @@ ltx-video retake \
 
 ---
 
+### 3. Full Retake with LoRA — Camera Motion Control
+
+Apply a compatible LoRA during retake generation (for example a camera-motion LoRA) using the same flags as `generate`.
+
+```bash
+ltx-video retake \
+    "Arc shot around a red vintage car parked on a forest road, cinematic lighting" \
+    --video source-car.mp4 \
+    --lora /path/to/lora.safetensors \
+    --lora-scale 0.8 \
+    -w 768 -h 512 -f 121 \
+    --seed 42 \
+    -o retake-lora-768x512-5s.mp4
+```
+
+| Parameter | Value |
+|-----------|-------|
+| Resolution | 768x512 |
+| Frames | 121 (5.0s at 24fps) |
+| Mode | Full retake |
+| LoRA | custom `.safetensors` |
+| LoRA scale | 0.8 |
+| Seed | 42 |
+
+---
+
 ## CLI Reference
 
 ```
@@ -130,6 +156,8 @@ ltx-video retake <prompt> --video <path> [options]
 | `-f, --frames` | `121` | Frame count (must be 8n+1) |
 | `--seed` | random | Random seed |
 | `--enhance-prompt` | off | Enhance prompt with Gemma VLM |
+| `--lora` | none | Path to LoRA `.safetensors` file |
+| `--lora-scale` | `1.0` | LoRA strength multiplier |
 | `--transformer-quant` | `bf16` | Quantization: `bf16`, `qint8`, `int4` |
 
 ### Strength Guide


### PR DESCRIPTION
This PR adds LoRA support to the retake workflow so users can apply a LoRA during video-to-video regeneration using the same flags as generate.

Changes:

1. Add retake LoRA CLI options and fusion flow:
- Add --lora and --lora-scale to retake.
- Validate LoRA path and scale before generation.
- Fuse LoRA after model loading and before retake inference.
2. Documentation updates:
- Add retake + LoRA usage example in top-level README.
- Add detailed retake example and CLI reference in docs/examples/retake/README.md.