### PR TITLE
Fix #27: document frames as float32 [0, 1]

### DIFF
--- a/Sources/LTXVideo/LTXVideo.swift
+++ b/Sources/LTXVideo/LTXVideo.swift
@@ -195,7 +195,7 @@ public struct VideoGenerationResult: @unchecked Sendable {
     /// Generated video frames as an MLX array.
     ///
     /// Shape: `(F, H, W, C)` where `F` = frame count, `H` = height,
-    /// `W` = width, `C` = 3 (RGB). Values are uint8 in `[0, 255]`.
+    /// `W` = width, `C` = 3 (RGB). Values are float32 in `[0, 1]`.
     public let frames: MLXArray
 
     /// Number of generated frames

--- a/Sources/LTXVideo/Utils/VideoExporter.swift
+++ b/Sources/LTXVideo/Utils/VideoExporter.swift
@@ -616,7 +616,7 @@ extension VideoExporter {
     /// second track — no separate WAV file needed.
     ///
     /// - Parameters:
-    ///   - frames: Video tensor of shape `(F, H, W, C)` or `(B, F, H, W, C)`, uint8 [0, 255]
+    ///   - frames: Video tensor of shape `(F, H, W, C)` or `(B, F, H, W, C)`, float32 [0, 1]
     ///   - width: Video width in pixels
     ///   - height: Video height in pixels
     ///   - fps: Frames per second (default: 24.0)


### PR DESCRIPTION
## Summary
- `VideoGenerationResult.frames` and `VideoExporter.exportVideo(frames:…)` docs claimed `uint8 [0, 255]`, but the VAE decode path returns float32 frames in `[0, 1]` (and the export pipeline expects float `[0, 1]`).
- Doc-only fix: updates the two public-facing comments to match actual behavior. No code change, no behavior change.

## Context
- `decodeVideo()` in `VideoDecoder.swift:331` does `MLX.clip((decoded + 1.0) / 2.0, min: 0, max: 1)` and its own internal doc already says "in [0, 1]".
- `tensorToImages()` in `VideoExporter.swift:550` doc already says "values in [0, 1]" and scales by 255 internally before casting to uint8 for AVAssetWriter.
- Only the public surface was misleading consumers.

Fixes #27.

## Test plan
- [ ] `swift build` succeeds (doc-only change, no behavioral risk).
- [ ] No grep hits remain for `uint8 [0, 255]` in `Sources/` referring to frame tensors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)